### PR TITLE
Tkt804 log am version

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,7 @@
 # Note: keep this file in wiki format for easy pasting to the gcf wiki
 
+ * Print AM version when logging that GENI AM is listening 
+
 gcf 2.8.1:
  * Give `omni-configure` the ability to find PKCS#8 private keys,
    not just PKCS#1. With openssl v1.0.0 PKCS#8 is the default, so new

--- a/src/gcf-am.py
+++ b/src/gcf-am.py
@@ -187,7 +187,7 @@ def main(argv=None):
         msg = "Unknown API version: %d. Valid choices are \"1\", \"2\", or \"3\""
         sys.exit(msg % (opts.api_version))
 
-    logging.getLogger('gcf-am').info('GENI AM Listening on port %s...' % (opts.port))
+    logging.getLogger('gcf-am').info('GENI AM (v%s) Listening on port %s...' % (opts.api_version, opts.port))
     ams.serve_forever()
 
 if __name__ == "__main__":


### PR DESCRIPTION
This closes track issue #804, so that AM version is logged when Aggregate manager successfully starts.

David