### PR TITLE
Reduce code duplication for credentials verification in am3.py 

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -30,6 +30,8 @@ gcf 2.10:
     (`HIGH:MEDIUM:!ADH:!SSLv2:!MD5:!RC4:@STRENGTH`) when using python2.7.
     This avoids some security issues, and allows older clients
     to connect to some updated servers. (#745)
+  * Rework the code that calls the cred verifier to reduce code duplication and make 
+    implementations deriving the ReferenceAggregateManager more easy to write. (#836)
 
 gcf 2.9:
  * Add Markdown style README, CONTRIBUTING and CONTRIBUTORS files. (#551)


### PR DESCRIPTION
Basically, all am3 calls have code that looks like this:
       # Note that verify throws an exception on failure.
       # Use the client PEM format cert as retrieved
       # from the https connection by the SecureXMLRPCServer
       # to identify the caller.
         credentials = [self.normalize_credential(c) for c in credentials]
         credentials = [c['geni_value'] for c in filter(isGeniCred, credentials)]
         try:
             creds = self._cred_verifier.verify_from_strings(self._server.get_pem_cert(),
                                                             credentials,
                                                             the_slice.urn,
                                                             privileges,
                                                             options)
         except Exception, e:
             raise xmlrpclib.Fault('Insufficient privileges', str(e))

This code duplication becomes very annoying when deriving ReferenceAggregateManager. I'm preparing a pull request to reduce this duplication.