### PR TITLE
Generalize catching ApiErrorException when AggregateManager calls the delegate

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -44,6 +44,8 @@ gcf 2.10:
   * Allow aggregate deployments to specify the delegate to use in the
     `gcf_config` file or on the command line, so as to be able to
     write delegates without touching the main gcf code, thereby easing maintenance (#837).
+  * When delegates raise an `ApiErrorException`, catch it to send back
+    a proper return value indicating an error occured. (#841)  
 
 gcf 2.9:
  * Add Markdown style README, CONTRIBUTING and CONTRIBUTORS files. (#551)

--- a/src/gcf/geni/am/am3.py
+++ b/src/gcf/geni/am/am3.py
@@ -1235,8 +1235,11 @@ class AggregateManager(object):
                              credentials,
                              args, options, is_v3=True) as amc:
             if not amc._error:
-                amc._result = \
-                    self._delegate.ListResources(credentials, amc._options)
+                try:
+                    amc._result = \
+                        self._delegate.ListResources(credentials, amc._options)
+                except ApiErrorException as e:
+                    return self._api_error(e)
         return amc._result
 
     def Allocate(self, slice_urn, credentials, rspec, options):
@@ -1256,9 +1259,12 @@ class AggregateManager(object):
             if not amc._error:
                 slice_urn = amc._args['slice_urn']
                 rspec = amc._args['rspec']
-                amc._result = \
-                    self._delegate.Allocate(slice_urn, credentials, 
-                                            rspec, amc._options)
+                try:
+                    amc._result = \
+                       self._delegate.Allocate(slice_urn, credentials, 
+                                               rspec, amc._options)
+                except ApiErrorException as e:
+                    return self._api_error(e)
         return amc._result
 
     def Provision(self, urns, credentials, options):
@@ -1274,8 +1280,11 @@ class AggregateManager(object):
                              args, options, is_v3=True) as amc:
             if not amc._error:
                 urns = amc._args['urns']
-                amc._result = \
-                    self._delegate.Provision(urns, credentials, amc._options)
+                try:
+                    amc._result = \
+                        self._delegate.Provision(urns, credentials, amc._options)
+                except ApiErrorException as e:
+                    return self._api_error(e)
         return amc._result
 
     def Delete(self, urns, credentials, options):
@@ -1289,8 +1298,11 @@ class AggregateManager(object):
                              args, options, is_v3=True) as amc:
             if not amc._error:
                 urns = amc._args['urns']
-                amc._result = \
-                    self._delegate.Delete(urns, credentials, amc._options)
+                try:
+                    amc._result = \
+                        self._delegate.Delete(urns, credentials, amc._options)
+                except ApiErrorException as e:
+                    return self._api_error(e)
         return amc._result
 
     def PerformOperationalAction(self, urns, credentials, action, options):
@@ -1308,10 +1320,13 @@ class AggregateManager(object):
             if not amc._error:
                 urns = amc._args['urns']
                 action = amc._args['action']
-                amc._result = \
-                    self._delegate.PerformOperationalAction(urns, credentials, 
-                                                            action, 
-                                                            amc._options)
+                try: 
+                    amc._result = \
+                        self._delegate.PerformOperationalAction(urns, credentials, 
+                                                                action, 
+                                                                amc._options)
+                except ApiErrorException as e:
+                    return self._api_error(e)
         return amc._result
 
     def Status(self, urns, credentials, options):
@@ -1325,8 +1340,11 @@ class AggregateManager(object):
                              args, options, is_v3 = True) as amc:
             if not amc._error:
                 urns = amc._args['urns']
-                amc._result = \
-                    self._delegate.Status(urns, credentials, amc._options)
+                try:
+                    amc._result = \
+                        self._delegate.Status(urns, credentials, amc._options)
+                except ApiErrorException as e:
+                    return self._api_error(e)
         return amc._result
 
     def Describe(self, urns, credentials, options):
@@ -1342,8 +1360,11 @@ class AggregateManager(object):
                              args, options, is_v3 = True) as amc:
             if not amc._error:
                 urns = amc._args['urns']
-                amc._result = \
-                    self._delegate.Describe(urns, credentials, amc._options)
+                try:
+                    amc._result = \
+                        self._delegate.Describe(urns, credentials, amc._options)
+                except ApiErrorException as e:
+                    return self._api_error(e)
         return amc._result
 
     def Renew(self, urns, credentials, expiration_time, options):
@@ -1359,9 +1380,12 @@ class AggregateManager(object):
             if not amc._error:
                 urns = amc._args['urns']
                 expiration_time = amc._args['expiration_time']
-                amc._result = \
-                    self._delegate.Renew(urns, credentials, expiration_time, 
-                                         amc._options)
+                try:
+                    amc._result = \
+                        self._delegate.Renew(urns, credentials, expiration_time, 
+                                             amc._options)
+                except ApiErrorException as e:
+                    return self._api_error(e)
         return amc._result
 
     def Shutdown(self, slice_urn, credentials, options):
@@ -1375,9 +1399,12 @@ class AggregateManager(object):
                              args, options, is_v3 = True) as amc:
             if not amc._error:
                 slice_urn = amc._args['slice_urn']
-                amc._result = \
-                    self._delegate.Shutdown(slice_urn, credentials, 
-                                            amc._options)
+                try:
+                    amc._result = \
+                        self._delegate.Shutdown(slice_urn, credentials, 
+                                                amc._options)
+                except ApiErrorException as e:
+                    return self._api_error(e)
         return amc._result
 
 

--- a/src/gcf/geni/am/am3.py
+++ b/src/gcf/geni/am/am3.py
@@ -63,6 +63,7 @@ from ...omnilib.util import credparsing as credutils
 
 from ..auth.base_authorizer import *
 from .am_method_context import AMMethodContext
+from .api_error_exception import ApiErrorException
 
 # See sfa/trust/rights.py
 # These are names of operations
@@ -132,16 +133,6 @@ class AM_API(object):
     ALREADY_EXISTS = 17
     # --- Non-standard errors below here. ---
     OUT_OF_RANGE = 19
-
-
-class ApiErrorException(Exception):
-    def __init__(self, code, output):
-        self.code = code
-        self.output = output
-
-    def __str__(self):
-        return "ApiError(%r, %r)" % (self.code, self.output)
-
 
 class Sliver(object):
     """A sliver is a single resource assigned to a single slice
@@ -1235,11 +1226,8 @@ class AggregateManager(object):
                              credentials,
                              args, options, is_v3=True) as amc:
             if not amc._error:
-                try:
-                    amc._result = \
-                        self._delegate.ListResources(credentials, amc._options)
-                except ApiErrorException as e:
-                    return self._api_error(e)
+                amc._result = \
+                    self._delegate.ListResources(credentials, amc._options)
         return amc._result
 
     def Allocate(self, slice_urn, credentials, rspec, options):
@@ -1259,12 +1247,9 @@ class AggregateManager(object):
             if not amc._error:
                 slice_urn = amc._args['slice_urn']
                 rspec = amc._args['rspec']
-                try:
-                    amc._result = \
-                       self._delegate.Allocate(slice_urn, credentials, 
-                                               rspec, amc._options)
-                except ApiErrorException as e:
-                    return self._api_error(e)
+                amc._result = \
+                    self._delegate.Allocate(slice_urn, credentials, 
+                                            rspec, amc._options)
         return amc._result
 
     def Provision(self, urns, credentials, options):
@@ -1280,11 +1265,8 @@ class AggregateManager(object):
                              args, options, is_v3=True) as amc:
             if not amc._error:
                 urns = amc._args['urns']
-                try:
-                    amc._result = \
-                        self._delegate.Provision(urns, credentials, amc._options)
-                except ApiErrorException as e:
-                    return self._api_error(e)
+                amc._result = \
+                    self._delegate.Provision(urns, credentials, amc._options)
         return amc._result
 
     def Delete(self, urns, credentials, options):
@@ -1298,11 +1280,8 @@ class AggregateManager(object):
                              args, options, is_v3=True) as amc:
             if not amc._error:
                 urns = amc._args['urns']
-                try:
-                    amc._result = \
-                        self._delegate.Delete(urns, credentials, amc._options)
-                except ApiErrorException as e:
-                    return self._api_error(e)
+                amc._result = \
+                    self._delegate.Delete(urns, credentials, amc._options)
         return amc._result
 
     def PerformOperationalAction(self, urns, credentials, action, options):
@@ -1320,13 +1299,10 @@ class AggregateManager(object):
             if not amc._error:
                 urns = amc._args['urns']
                 action = amc._args['action']
-                try: 
-                    amc._result = \
-                        self._delegate.PerformOperationalAction(urns, credentials, 
-                                                                action, 
-                                                                amc._options)
-                except ApiErrorException as e:
-                    return self._api_error(e)
+                amc._result = \
+                    self._delegate.PerformOperationalAction(urns, credentials, 
+                                                            action, 
+                                                            amc._options)
         return amc._result
 
     def Status(self, urns, credentials, options):
@@ -1340,11 +1316,8 @@ class AggregateManager(object):
                              args, options, is_v3 = True) as amc:
             if not amc._error:
                 urns = amc._args['urns']
-                try:
-                    amc._result = \
-                        self._delegate.Status(urns, credentials, amc._options)
-                except ApiErrorException as e:
-                    return self._api_error(e)
+                amc._result = \
+                    self._delegate.Status(urns, credentials, amc._options)
         return amc._result
 
     def Describe(self, urns, credentials, options):
@@ -1360,11 +1333,8 @@ class AggregateManager(object):
                              args, options, is_v3 = True) as amc:
             if not amc._error:
                 urns = amc._args['urns']
-                try:
-                    amc._result = \
-                        self._delegate.Describe(urns, credentials, amc._options)
-                except ApiErrorException as e:
-                    return self._api_error(e)
+                amc._result = \
+                    self._delegate.Describe(urns, credentials, amc._options)
         return amc._result
 
     def Renew(self, urns, credentials, expiration_time, options):
@@ -1380,12 +1350,9 @@ class AggregateManager(object):
             if not amc._error:
                 urns = amc._args['urns']
                 expiration_time = amc._args['expiration_time']
-                try:
-                    amc._result = \
-                        self._delegate.Renew(urns, credentials, expiration_time, 
-                                             amc._options)
-                except ApiErrorException as e:
-                    return self._api_error(e)
+                amc._result = \
+                    self._delegate.Renew(urns, credentials, expiration_time, 
+                                         amc._options)
         return amc._result
 
     def Shutdown(self, slice_urn, credentials, options):
@@ -1399,12 +1366,9 @@ class AggregateManager(object):
                              args, options, is_v3 = True) as amc:
             if not amc._error:
                 slice_urn = amc._args['slice_urn']
-                try:
-                    amc._result = \
-                        self._delegate.Shutdown(slice_urn, credentials, 
-                                                amc._options)
-                except ApiErrorException as e:
-                    return self._api_error(e)
+                amc._result = \
+                    self._delegate.Shutdown(slice_urn, credentials, 
+                                            amc._options)
         return amc._result
 
 

--- a/src/gcf/geni/am/am_method_context.py
+++ b/src/gcf/geni/am/am_method_context.py
@@ -32,7 +32,7 @@ from ...sfa.trust.certificate import Certificate
 from ...sfa.trust.abac_credential import ABACCredential
 from ..util.speaksfor_util import determine_speaks_for
 from ..SecureThreadedXMLRPCServer import SecureThreadedXMLRPCRequestHandler
-
+from .api_error_exception import ApiErrorException
 
 # A class to support wrapping AM API calls from AggregateManager
 # to the delegate to check for authorization and perform speaks-for
@@ -151,7 +151,11 @@ class AMMethodContext:
     # type, value is the exception and traceback_object is the stack trace
     # Otherwise, these arguments are all none
     def __exit__(self, type, value, traceback_object):
-        if type:
+        if type is ApiErrorException:
+            self._logger.exception("Error in %s" % self._method_name)
+            self._result=self._api_error(value);
+            self._error = True
+        elif type:
             self._logger.exception("Error in %s" % self._method_name)
             self._handleError(value)
 

--- a/src/gcf/geni/am/api_error_exception.py
+++ b/src/gcf/geni/am/api_error_exception.py
@@ -1,0 +1,38 @@
+#----------------------------------------------------------------------
+# Copyright (c) 2012-2015 Raytheon BBN Technologies
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and/or hardware specification (the "Work") to
+# deal in the Work without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Work, and to permit persons to whom the Work
+# is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Work.
+#
+# THE WORK IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS
+# IN THE WORK.
+#----------------------------------------------------------------------
+"""
+When AggregateManager delegate's raise that type of exception, the result of
+the current call will be a well formatted result, with a message as in 
+{ 'output': 'exception output', 
+  'code': {'am_type': 'gcf', 
+           'geni_code': <exception code>}, 
+  'value': ''}
+"""
+
+class ApiErrorException(Exception):
+    def __init__(self, code, output):
+        self.code = code
+        self.output = output
+
+    def __str__(self):
+        return "ApiError(%r, %r)" % (self.code, self.output)

--- a/src/gcf/geni/am/test_ams.py
+++ b/src/gcf/geni/am/test_ams.py
@@ -1,0 +1,36 @@
+#----------------------------------------------------------------------
+# Copyright (c) 2015 Inria by David Margery
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and/or hardware specification (the "Work") to
+# deal in the Work without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Work, and to permit persons to whom the Work
+# is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Work.
+#
+# THE WORK IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS
+# IN THE WORK.
+#----------------------------------------------------------------------
+"""
+An aggregate manager delegate that raises APIErrorException to test
+behavior in gcf.geni.am.am3.AggregateManager when calling a delagate
+that raises an exception
+"""
+
+import gcf.geni.am.am3 as am3
+
+class ExceptionRaiserDelegate(am3.ReferenceAggregateManager):
+    def __init__(self, root_cert, urn_authority, url, **kwargs):
+        super(ExceptionRaiserDelegate,self).__init__(root_cert,urn_authority,url,**kwargs)
+    
+    def Shutdown(self, slice_urn, credentials, options):
+        raise am3.ApiErrorException(am3.AM_API.REFUSED, "test exception")


### PR DESCRIPTION
This would enable cleaner error messages for clients when the delegate implementation fails.

In the current code, I only see this applied for the `GetVersion` implementation of `am3.AggregateManager`.

Pull request with candidate implementation to follow 