### PR TITLE
Fix typos in Provision() for issue #846

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -47,6 +47,7 @@ gcf 2.10:
   * When delegates raise an `ApiErrorException`, catch it to send back
     a proper return value indicating an error occured. (#841)
   * Log the HTTP request line when `--debug`. (#842)
+  * Fix some typos in `Provision()` in `am3.py`. (#846)
 
 gcf 2.9:
  * Add Markdown style README, CONTRIBUTING and CONTRIBUTORS files. (#551)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,6 +11,7 @@ Have a suggestion, feature request, or issue to report? Read about how to [contr
 Contributors recognized by GitHub are listed [on GitHub](https://github.com/GENI-NSF/geni-tools/graphs/contributors).
 
 Past contributors have included:
+ - Alvaro Manuel Recio Perez, University of Malaga
  - David Margery, Inria
  - Tomasz Buchert, Inria
  - Ezra Kissel, Indiana University

--- a/README-omni.txt
+++ b/README-omni.txt
@@ -41,6 +41,8 @@ tips, see the Omni Wiki: http://trac.gpolab.bbn.com/gcf/wiki/Omni
 
 == Release Notes ==
 
+ * Fix typo in `Provision()`. (#846)
+
 New in v2.10:
  * Continue anyway if no aggregate nickname cache can be loaded. (#822)
   * Sliver info reporting and operations on AMs by nickname will likely fail.

--- a/README-omni.txt
+++ b/README-omni.txt
@@ -41,8 +41,6 @@ tips, see the Omni Wiki: http://trac.gpolab.bbn.com/gcf/wiki/Omni
 
 == Release Notes ==
 
- * Fix typo in `Provision()`. (#846)
-
 New in v2.10:
  * Continue anyway if no aggregate nickname cache can be loaded. (#822)
   * Sliver info reporting and operations on AMs by nickname will likely fail.

--- a/src/gcf/geni/am/am3.py
+++ b/src/gcf/geni/am/am3.py
@@ -569,7 +569,7 @@ class ReferenceAggregateManager(object):
         # EG the 'info' privilege in a credential allows the operations
         # listslices, listnodes, policy
         privileges = (PROVISION_PRIV,)
-        creds = self.getverifiedcredentials(the_slice.urn, credentials, options, privileges)
+        creds = self.getVerifiedCredentials(the_slice.urn, credentials, options, privileges)
 
         if 'geni_rspec_version' not in options:
             # This is a required option, so error out with bad arguments.
@@ -617,7 +617,7 @@ class ReferenceAggregateManager(object):
                                       and options['geni_end_time']))
         for sliver in slivers:
             # Extend the lease and set to PROVISIONED
-            expiration = min(sliver.getEndTime(), max_expiration)
+            expiration = min(sliver.endTime(), max_expiration)
             sliver.setEndTime(expiration)
             sliver.setExpiration(expiration)
             sliver.setAllocationState(STATE_GENI_PROVISIONED)


### PR DESCRIPTION
Corrected spelling of functions names as explained in issue #846.