### PR TITLE
keep resources' states updated in am2

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -49,6 +49,7 @@ gcf 2.10:
   * Log the HTTP request line when `--debug`. (#842)
   * Fix some typos in `Provision()` in `am3.py`. (#846)
   * Add Debian and RPM packaging configuration (#849)
+  * Fix am2 not keeping resources' state updated when creating or deleting Slivers (#848)
 
 gcf 2.9:
  * Add Markdown style README, CONTRIBUTING and CONTRIBUTORS files. (#551)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -24,5 +24,6 @@ Past contributors have included:
  - Sarah Edwards, Raytheon BBN Technologies
  - Tom Mitchell, Raytheon BBN Technologies
  - Aaron Helsinger, Raytheon BBN Technologies
+ - Eduardo Miravalls Sierra, HPCN Lab of University UAM
 
 Thank you!

--- a/src/gcf/geni/am/am2.py
+++ b/src/gcf/geni/am/am2.py
@@ -357,6 +357,7 @@ class ReferenceAggregateManager(object):
         for cid, r in resources.items():
             newslice.resources[cid] = r.id
             r.status = Resource.STATUS_READY
+            r.available = False
         self._slices[slice_urn] = newslice
 
         self.logger.info("Created new slice %s" % slice_urn)
@@ -408,10 +409,12 @@ class ReferenceAggregateManager(object):
                 self.logger.info("Sliver %s not deleted because it is shutdown",
                                  slice_urn)
                 return self.errorResult(11, "Unavailable: Slice %s is unavailable." % (slice_urn))
+
+            for r in resources:
+                r.reset()
+
             self._agg.deallocate(slice_urn, None)
             self._agg.deallocate(user_urn, None)
-            for r in resources:
-                r.status = Resource.STATUS_UNKNOWN
             del self._slices[slice_urn]
             self.logger.info("Sliver %r deleted" % slice_urn)
             return self.successResult(True)


### PR DESCRIPTION
This is my suggested fix for issue #848.

I've removed all those whitespace errors that appeared in my patch as @tcmitchell asked.