### PR TITLE
Call am3.decode_urns from AMMethodContext with credential information

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -26,6 +26,9 @@ gcf 2.10:
   * AL2S supports speaks for. Don't exit if using speaksfor and AL2S. (#834)
 
  * gcf
+  * Add new parameters to decode_urns so that derived delegates can 
+    decode urns using the credentials and options available in other 
+    calls (#858)
   * Add utility function to derive the effective user's client cert, after
     accounting for speaks-for. This allows an AM to know the "real" user's URN
     and email, for example (#831)

--- a/src/gcf/geni/am/am3.py
+++ b/src/gcf/geni/am/am3.py
@@ -1102,6 +1102,12 @@ class ReferenceAggregateManager(object):
         """Several methods need to map URNs to slivers and/or deduce
         a slice based on the slivers specified.
 
+        When called from AMMethodContext, kwargs will have 2 keys
+        (credentials and options), with the same values as the credentials
+        and options parameters of the AMv3 API entry points. This can be 
+        usefull for delegates derived from the ReferenceAggregateManager, 
+        but is not used in this reference implementation.
+
         Returns a slice and a list of slivers.
         """
         slivers = list()

--- a/src/gcf/geni/am/am3.py
+++ b/src/gcf/geni/am/am3.py
@@ -1098,7 +1098,7 @@ class ReferenceAggregateManager(object):
                 self.logger.debug("Deleting empty slice %r", slyce.urn)
                 del self._slices[slyce.urn]
 
-    def decode_urns(self, urns):
+    def decode_urns(self, urns, **kwargs):
         """Several methods need to map URNs to slivers and/or deduce
         a slice based on the slivers specified.
 

--- a/src/gcf/geni/am/am_method_context.py
+++ b/src/gcf/geni/am/am_method_context.py
@@ -103,13 +103,15 @@ class AMMethodContext:
                 self._aggregate_manager._delegate._my_urn
 
             if self._is_v3:
+                credentials = self._normalize_credentials(self._credentials)
                 if 'urns' in self._args: 
                     urns = self._args['urns']
                     the_slice, the_slivers = \
-                        self._aggregate_manager._delegate.decode_urns(urns)
+                        self._aggregate_manager._delegate.decode_urns(urns,
+                                                                      credentials=credentials,
+                                                                      options=self._options)
                     if the_slice and 'slice_urn' not in self._args:
                         self._args['slice_urn'] = the_slice.getURN()
-                credentials = self._normalize_credentials(self._credentials)
 
             if self._authorizer is not None:
                 requested_allocation_state = []


### PR DESCRIPTION
Hello,

I have stumbled into a pain point for my implementation of a BonFIRE delegate. The BonFIRE delegate is stateless, and therefore does not keep track of the relationship between slivers and the related slice.

It relies for that on data accessed through the underlying BonFIRE API, because sliver ids can be mapped to BonFIRE ids. It is possible to request detailed information for a resource, that includes slice id from the BonFIRE API using that BonFIRE id. But getting that information is a privileged call : only the owners/users of the resource can view that information.

Therefore, implementing the `decode_urn` method properly for the BonFIRE delegate would imply being able to access the credentials of the caller to authenticate the user when calling the BonFIRE API. I've been able to manage this from the delegate's methods rather seamlessly, using an internal method that is called with the list of urn and credential information until I discovered that in some cases, `AMMethodContext` will also directly call decode_urns. This implies 

1. That delegates not relying on the `ReferenceAggregateManager` implementation of slice and sliver bookkeeping need to implement that method
2. in my case, that that method needs to be called with more parameters.

I'm considering a patch using kwargs or simply using the `options` dict as optional argument. Any opinions ?

David

 

