### PR TITLE
issue #857: do not assume project_member_uid is returned by listprojectmembers

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,12 @@ gcf 2.10:
     (`HIGH:MEDIUM:!ADH:!SSLv2:!MD5:!RC4:@STRENGTH`) when using python2.7.
     This avoids some security issues, and allows Omni on older clients
     to connect to some updated servers. (#745)
+  * Use `False` instead of `'f'` for `SLICE_EXPIRED` and `PROJECT_EXPIRED` when 
+    using Common Federation API clearinghouses. (#856)
+   * Thanks to Umar Toseef for the bug report.
+  * Do not assume `PROJECT_MEMBER_UID` is returned when listing project members,
+    but allow it. (#857)
+   * Thanks to Umar Toseef for the bug report.
 
  * Stitcher
   * Catch expiration too great errors from PG AMs and quit. (#828)
@@ -55,9 +61,6 @@ gcf 2.10:
     modern values (#851)
   * Update CentOS installation instructions (#853)
   * Point people to gcf-developers@googlegroups.com instead of old list.
-  * Use `False` instead of `'f'` for `SLICE_EXPIRED` and `PROJECT_EXPIRED` when 
-    using Common Federation API clearinghouses. (#856)
-   * Thanks to Umar Toseef for the bug report.
 
 gcf 2.9:
  * Add Markdown style README, CONTRIBUTING and CONTRIBUTORS files. (#551)

--- a/README-omni.txt
+++ b/README-omni.txt
@@ -49,6 +49,12 @@ New in v2.10:
    (`HIGH:MEDIUM:!ADH:!SSLv2:!MD5:!RC4:@STRENGTH`) when using python2.7.
    This avoids some security issues, and allows Omni on older clients
    to connect to some updated servers. (#745)
+ * Use `False` instead of `'f'` for `SLICE_EXPIRED` and `PROJECT_EXPIRED` when 
+   using Common Federation API clearinghouses. (#856)
+  * Thanks to Umar Toseef for the bug report.
+ * Do not assume `PROJECT_MEMBER_UID` is returned when listing project members,
+   but allow it. (#857)
+  * Thanks to Umar Toseef for the bug report.
 
 New in v2.9:
  * If `sliverstatus` fails in a way that indicates there are no local resources,
@@ -1350,7 +1356,8 @@ clearinghouse. For each such user, the return includes:
  - `PROJECT_MEMBER`: URN identifier of the user
  - `EMAIL` address of the user
  - `PROJECT_ROLE` of the user in the project.
- - `PROJECT_MEMBER_UID`: Internal UID identifier of the member
+ - `PROJECT_MEMBER_UID`: Internal UID identifier of the member, if
+ returned by the clearingnouse and the user supplied `--debug`
 
 Output directing options:
  * `-o` Save result in a file

--- a/src/gcf/omnilib/chhandler.py
+++ b/src/gcf/omnilib/chhandler.py
@@ -871,7 +871,7 @@ class CHCallHandler(object):
         """List all the members of a project
         Args: projectname
         Return summary string and list of member dictionaries
-        containing PROJECT_MEMBER (URN), EMAIL, PROJECT_MEMBER_UID, and PROJECT_ROLE.
+        containing PROJECT_MEMBER (URN), EMAIL, [optional: PROJECT_MEMBER_UID], and PROJECT_ROLE.
 
         Output directing options:
         -o Save result in a file
@@ -907,7 +907,7 @@ class CHCallHandler(object):
                 prettyResult += '   Email = ' + str(member['EMAIL']) + '\n'
                 if member.has_key('PROJECT_ROLE'):
                     prettyResult += '   Role = ' + str(member['PROJECT_ROLE']) + '\n'
-                if self.opts.debug or self.opts.devmode:
+                if (self.opts.debug or self.opts.devmode) and member.has_key('PROJECT_MEMBER_UID'):
                     prettyResult += '   UID = ' + member['PROJECT_MEMBER_UID'] + '\n'
 
             header=None

--- a/src/gcf/omnilib/frameworks/framework_chapi.py
+++ b/src/gcf/omnilib/frameworks/framework_chapi.py
@@ -1411,7 +1411,7 @@ class Framework(Framework_Base):
     def get_members_of_project(self, project_name):
         '''Look up members of the project with the given name.
         Return is a list of member dictionaries
-        containing PROJECT_MEMBER (URN), EMAIL, PROJECT_MEMBER_UID, and PROJECT_ROLE.
+        containing PROJECT_MEMBER (URN), EMAIL, [if found: PROJECT_MEMBER_UID], and PROJECT_ROLE.
         '''
         # Bail if projects not supported
         if not self.useProjects:
@@ -1446,14 +1446,15 @@ class Framework(Framework_Base):
         if logr == True:
             if res['value']:
                 for member_vals in res['value']:
-                    # Entries: PROJECT_MEMBER, PROJECT_ROLE, PROJECT_MEMBER_UID
+                    # Entries: PROJECT_MEMBER, PROJECT_ROLE, optional: PROJECT_MEMBER_UID
                     # self.logger.debug("Got member value: %s", member_vals)
                     member_urn = member_vals['PROJECT_MEMBER']
                     member_role = member_vals['PROJECT_ROLE']
                     member = {'PROJECT_MEMBER': member_urn}
                     member['EMAIL'] = self._get_member_email(member_urn)
                     member['PROJECT_ROLE'] = member_role
-                    member['PROJECT_MEMBER_UID'] = member_vals['PROJECT_MEMBER_UID']
+                    if member_vals.has_key('PROJECT_MEMBER_UID'):
+                        member['PROJECT_MEMBER_UID'] = member_vals['PROJECT_MEMBER_UID']
                     members.append(member)
         else:
             mess = logr


### PR DESCRIPTION
do not assume project_member_uid is returned by listprojectmembers. But allow and return it if it is returned. This makes omni work with chapi compliant CHs, while also returning the extra info that the GENI CH returns.
