### PR TITLE
Issue #863. AM3 must store resources, not slivers

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -65,6 +65,7 @@ gcf 2.10:
     modern values (#851)
   * Update CentOS installation instructions (#853)
   * Point people to gcf-developers@googlegroups.com instead of old list.
+  * In AM3, fix exception on expire_slivers. Aggregate stores resources, not slivers. (#863)
 
 gcf 2.9:
  * Add Markdown style README, CONTRIBUTING and CONTRIBUTORS files. (#551)

--- a/src/gcf/geni/am/aggregate.py
+++ b/src/gcf/geni/am/aggregate.py
@@ -29,7 +29,7 @@ class Aggregate(object):
 
     def __init__(self):
         self.resources = []
-        self.containers = {}
+        self.containers = {} # of resources, not slivers
 
     def add_resources(self, resources):
         self.resources.extend(resources)

--- a/src/gcf/geni/am/am3.py
+++ b/src/gcf/geni/am/am3.py
@@ -539,8 +539,8 @@ class ReferenceAggregateManager(object):
             sliver.setStartTime(start_time)
             sliver.setEndTime(end_time)
             sliver.setAllocationState(STATE_GENI_ALLOCATED)
-        self._agg.allocate(slice_urn, newslice.slivers())
-        self._agg.allocate(user_urn, newslice.slivers())
+        self._agg.allocate(slice_urn, newslice.resources())
+        self._agg.allocate(user_urn, newslice.resources())
         self._slices[slice_urn] = newslice
 
         # Log the allocation
@@ -648,9 +648,9 @@ class ReferenceAggregateManager(object):
             return self.errorResult(AM_API.UNAVAILABLE,
                                     ("Unavailable: Slice %s is unavailable."
                                      % (the_slice.urn)))
-
-        self._agg.deallocate(the_slice.urn, slivers)
-        self._agg.deallocate(user_urn, slivers)
+        resources = [sliver.resource() for sliver in slivers]
+        self._agg.deallocate(the_slice.urn, resources)
+        self._agg.deallocate(user_urn, resources)
         for sliver in slivers:
             slyce = sliver.slice()
             slyce.delete_sliver(sliver)


### PR DESCRIPTION
Fix exception on expire_slivers in GCF AM3. It was storing slivers in the per-slice collection in the aggregate object, but it is supposed to be resources instead. So pass the collection of resources to agg.allocate() and agg.deallocate(), instead of the collection of slivers.