### PR TITLE
Issue #814: Change references to trac.gpolab gcf wiki to github

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,10 @@
 # Note: keep this file in wiki format for easy pasting to the gcf wiki
 
 gcf 2.10:
+ * Changed references to trac.gpolab.bbn.com to point to Github.
+   Although those pages mostly still reference trac, that is the future home.
+   These changes include changing where the agg_nick_cache lives. (#814)
+
  * Omni
   * Continue anyway if no aggregate nickname cache can be loaded. (#822)
    * Sliver info reporting and operations on AMs by nickname will likely fail.
@@ -18,6 +22,7 @@ gcf 2.10:
   * Calling `getslicecred` while specifying a `slicecredfile` that exists
     no longer means just return that file. Instead, that file will be
     ignored and, if you specify `-o`, replaced. (#868)
+  * Moved canonical `agg_nick_cache` location to Github. (#814)
 
  * Stitcher
   * Catch expiration too great errors from PG AMs and quit. (#828)

--- a/INSTALL.macos
+++ b/INSTALL.macos
@@ -1,7 +1,7 @@
 == Mac OS X ==
 
 Pre-built binaries for Mac OS X Omni tools (not including the gcf tools for developers) are
-available for download from https://trac.gpolab.bbn.com/gcf. If
+available for download from https://github.com/GENI-NSF/geni-tools/wiki. If
 that is not appropriate for you, follow the instructions below.
 
 === Using homebrew ===

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -7,7 +7,7 @@ README-omni.txt for details on Omni.
 
 Omni users should follow these install instructions to ensure software dependencies are met.
 Omni users using Mac OS X or Windows might consider the pre-built binaries available
-from https://trac.gpolab.bbn.com/gcf.
+from https://github.com/GENI-NSF/geni-tools/wiki.
 
 Upgrading? For upgrading instructions look at the end of this file.
 

--- a/README-gcf.txt
+++ b/README-gcf.txt
@@ -1,8 +1,8 @@
 [[PageOutline]]
 {{{
 #!comment
-This is formatted as a wiki page:
-README-gcf.txt -> http://trac.gpolab.bbn.com/gcf/wiki/GcfQuickStart
+This is formatted as a wiki page, currently for trac:
+README-gcf.txt -> https://github.com/GENI-NSF/geni-tools/wiki/GCF-Quick-Start
 }}}
 
 = gcf Configuration and Test Run =

--- a/README-omni.txt
+++ b/README-omni.txt
@@ -19,11 +19,11 @@ users with GENI accounts (credentials) that they can use to
 reserve resources in GENI AMs.
 
 See INSTALL.txt or 
-[http://trac.gpolab.bbn.com/gcf/wiki/QuickStart the Installation instructions] 
+[https://github.com/GENI-NSF/geni-tools/wiki/QuickStart the Installation instructions] 
 for details on installing Omni.
 
-See README-omniconfigure.txt or 
-http://trac.gpolab.bbn.com/gcf/wiki/OmniConfigure/Automatic for details about how to configure Omni.
+See README-omniconfigure.txt or
+https://github.com/GENI-NSF/geni-tools/wiki/Omni-Configuration-Automatically for details about how to configure Omni.
 
 For 'stitching' (experimenter defined custom topologies) or
 multi-aggregate topologies, see README-stitching.txt.
@@ -37,7 +37,7 @@ Omni performs the following functions:
  * Contacts AMs via the GENI AM API
 
 For the latest Omni documentation, examples, and trouble shooting
-tips, see the Omni Wiki: http://trac.gpolab.bbn.com/gcf/wiki/Omni
+tips, see the Omni Wiki: https://github.com/GENI-NSF/geni-tools/wiki/Omni
 
 == Release Notes ==
 
@@ -58,6 +58,7 @@ New in v2.10:
  * Calling `getslicecred` while specifying a `slicecredfile` that exists
    no longer means just return that file. Instead, that file will be
    ignored and, if you specify `-o`, replaced. (#868)
+ * Moved canonical `agg_nick_cache` location to Github. (#814)
 
 New in v2.9:
  * If `sliverstatus` fails in a way that indicates there are no local resources,
@@ -466,9 +467,9 @@ Omni scripting allows a script to:
  * Control or suppress the logging in Omni (see the above section for details)
 
 For examples, see `src/stitcher.py` or `examples/expirationofmyslices.py` and `examples/myscript.py` in the gcf distribution.
-Or [http://trac.gpolab.bbn.com/gcf/wiki/OmniScriptingExpiration Omni Scripting Expiration] 
+Or [https://github.com/GENI-NSF/geni-tools/wiki/Omni-Scripting-Example-Showing-Expiration Omni Scripting Expiration] 
 and
-[http://trac.gpolab.bbn.com/gcf/wiki/OmniScriptingWithOptions Omni Scripting with Options] 
+[https://github.com/GENI-NSF/geni-tools/wiki/Omni-Scripting-Example-With-Options Omni Scripting with Options] 
 on the gcf wiki.
 
 '''NOTE''': Omni uses multiple command line options, and creates its
@@ -695,7 +696,7 @@ omni.py [options] [--project <proj_name>] <command and arguments>
  			 print_sliver_expirations <slicename> 
 
 	 See README-omni.txt for details.
-	 And see the Omni website at http://trac.gpolab.bbn.com/gcf
+	 And see the Omni website at https://github.com/GENI-NSF/geni-tools/wiki
 
 Options:
   --version             show program's version number and exit
@@ -851,9 +852,9 @@ Options:
                         ~/.gcf/agg_nick_cache
     --AggNickDefinitiveLocation=AGGNICKDEFINITIVELOCATION
                         Website with latest agg_nick_cache, default is
-                        http://trac.gpolab.bbn.com/gcf/raw-
-                        attachment/wiki/Omni/agg_nick_cache. To force Omni to
-                        read this cache, delete your local AggNickCache or use
+                        https://raw.githubusercontent.com/wiki/GENI-NSF/geni-
+                        tools/agg_nick_cache. To force Omni to read this
+                        cache, delete your local AggNickCache or use
                         --NoAggNickCache.
 
   For Developers / Advanced Users:

--- a/README-omniconfigure.txt
+++ b/README-omniconfigure.txt
@@ -131,14 +131,14 @@ Embedded comments describe the meaning of each field.
 (Note that keys for the GCF framework are stored in ~/.gcf by default.)
 
 For step-by-step instructions about how to configure Omni, please look at:
-http://trac.gpolab.bbn.com/gcf/wiki/OmniConfigure/Automatic
+https://github.com/GENI-NSF/geni-tools/wiki/Omni-Configuration-Automatically
 
 == Certificate passphrase ==
 While executing Omni, you will be prompted for the passphrase of your
 certificate multiple times per call. You should keep a passphrase on 
 your certificate for security best practices. If you just want a way 
 to type your passphrase only once per session look at:
-http://trac.gpolab.bbn.com/gcf/wiki/OmniTroubleShoot#Q.WhydoesOmnipromptformyPEMpassphrasesomanytimesCantOmnipromptonlyonce
+https://github.com/GENI-NSF/geni-tools/wiki/Omni-Troubleshooting#q-why-does-omni-prompt-for-my-pem-passphrase-so-many-times-cant-omni-prompt-only-once
 
 Also there is a script that will help removing the passphrase from the
 certificate. Look at README-clearpassphrases.txt. 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ experimentation, research and classroom use.
 
 The [GENI Aggregate Manager API](http://groups.geni.net/geni/wiki/GeniApi) defines the interface for software that resource owners run to manage access to their resources.
 
-For download and installation instructions, see our [Trac site](http://trac.gpolab.bbn.com/gcf).
+For download and installation instructions, see our [wiki](https://github.com/GENI-NSF/geni-tools/wiki).
 
 geni-tools is a community developed package. Please [contribute](CONTRIBUTING.md)!
 
-For further information on Omni, see the [Omni wiki](http://trac.gpolab.bbn.com/gcf)
+For further information on Omni, see the [Omni wiki](https://github.com/GENI-NSF/geni-tools/wiki)
 and [Omni README](README-omni.txt).
 
-For further information on the GCF aggregate, also see <http://trac.gpolab.bbn.com/gcf> and the [GCF README](README.txt).
+For further information on the GCF aggregate, also see <https://github.com/GENI-NSF/geni-tools/wiki> and the [GCF README](README.txt).
 
 geni-tools is released under the terms of the [GENI Public License](LICENSE.txt).

--- a/README.txt
+++ b/README.txt
@@ -287,8 +287,8 @@ credentials and certificates, and the GENI AM API.
 
 See http://groups.geni.net/geni/wiki/GeniApi
 
-Omni tutorials and further documentation are on the GCF Wiki:
-http://trac.gpolab.bbn.com/gcf. GCF and Omni source, and all
+Omni tutorials and further documentation are available on the wiki:
+https://github.com/GENI-NSF/geni-tools/wiki. GCF and Omni source, and all
 known issues in this package, are availble on Github:
 https://github.com/GENI-NSF/geni-tools.
 

--- a/TROUBLESHOOTING.txt
+++ b/TROUBLESHOOTING.txt
@@ -2,7 +2,7 @@ Troubleshooting Guide for GCF and Omni
 ======================================
 
 More documentation is on the GCF and Omni Wiki.
-http://trac.gpolab.bbn.com/gcf
+https://github.com/GENI-NSF/geni-tools/wiki
 
 For troubleshooting and tips, see:
-http://trac.gpolab.bbn.com/gcf/wiki/OmniTroubleShoot
+https://github.com/GENI-NSF/geni-tools/wiki/Omni-Troubleshooting

--- a/acceptance_tests/AM_API/README-accept-AMAPI.txt
+++ b/acceptance_tests/AM_API/README-accept-AMAPI.txt
@@ -71,7 +71,7 @@ Test verifies:
 
 Requires:
  * Omni and the acceptance tests which are distributed as part of the
-   [http://trac.gpolab.bbn.com/gcf/wiki gcf] package
+   [https://github.com/GENI-NSF/geni-tools/wiki gcf] package
  * (optional)
    [http://www.protogeni.net/trac/protogeni/wiki/RSpecDebugging rspeclint]
 
@@ -592,9 +592,9 @@ Options:
                         ~/.gcf/agg_nick_cache
     --AggNickDefinitiveLocation=AGGNICKDEFINITIVELOCATION
                         Website with latest agg_nick_cache, default is
-                        http://trac.gpolab.bbn.com/gcf/raw-
-                        attachment/wiki/Omni/agg_nick_cache. To force Omni to
-                        read this cache, delete your local AggNickCache or use
+                        https://raw.githubusercontent.com/wiki/GENI-NSF/geni-
+                        tools/agg_nick_cache. To force Omni to read this
+                        cache, delete your local AggNickCache or use
                         --NoAggNickCache.
 
   For Developers / Advanced Users:
@@ -758,7 +758,7 @@ they are supposed to expire - including freeing resources.
  2. AM API v2 change set A documentation: http://groups.geni.net/geni/wiki/GAPI_AM_API_V2_DELTAS#ChangeSetA
  3. AM API v2 documentation: http://groups.geni.net/geni/wiki/GAPI_AM_API_V2
  3. AM API v3 documentation: http://groups.geni.net/geni/wiki/GAPI_AM_API_V3
- 4. gcf and Omni documentation: http://trac.gpolab.bbn.com/gcf/wiki
+ 4. gcf and Omni documentation: https://github.com/GENI-NSF/geni-tools/wiki
  5. rspeclint code: http://www.protogeni.net/resources/rspeclint
  6. rspeclint documentation: http://www.protogeni.net/trac/protogeni/wiki/RSpecDebugging
 

--- a/agg_nick_cache.base
+++ b/agg_nick_cache.base
@@ -1,6 +1,6 @@
 ### DO NOT MODIFY THIS FILE BY HAND ###
-# This file lives at: http://trac.gpolab.bbn.com/gcf/raw-attachment/wiki/Omni/agg_nick_cache
-# Last updated on July 6, 2015
+# This file lives at: https://raw.githubusercontent.com/wiki/GENI-NSF/geni-tools/agg_nick_cache
+# Last updated on December 9, 2015
 
 [omni_defaults]
 # This section is for updating Omni defaults without updating Omni.
@@ -26,7 +26,7 @@ scs_url=https://geni-scs.net.internet2.edu:8443/geni/xmlrpc
 # Specify the latest version of Omni released, and a message
 # Expected format is "#,Message" EG: "2.8,Omni 2.8 was release 2/1/2015". No commas in the message.
 # If a newer version is available, Omni will log a message at INFO level.
-latest_omni_version=2.9,Omni 2.9 was released 5/27/2015. See http://trac.gpolab.bbn.com/gcf
+latest_omni_version=2.9,Omni 2.9 was released 5/27/2015. See https://github.com/GENI-NSF/geni-tools/wiki
 
 #------AM nicknames
 # Format :

--- a/doc/CreatingBinaries.md
+++ b/doc/CreatingBinaries.md
@@ -76,7 +76,7 @@ The installer setup file is `package_builder.iss`. It was created using http://s
 * Test installation.
  * Inno Setup will likely run the setup tool itself automatically.
   * Check the menu items all open the proper files: Disclaimer opens License, 2 web links, and the uninstall tool
- * Follow the rest of the install instructions starting with step 2 [here](http://trac.gpolab.bbn.com/gcf/wiki/Windows#Install)
+ * Follow the rest of the install instructions starting with step 2 [here](https://github.com/GENI-NSF/geni-tools/wiki/Windows#install)
   * Put the Omni tools on your path
  * Open a new command window, and test that all the executables run
 
@@ -205,7 +205,7 @@ Lots of stuff will print out.
 * Test dmg
  * Open the dmg
  * Test doing the install by dragging `OmniTools` to `Applications`
- * Follow the [install instructions](http://trac.gpolab.bbn.com/gcf/wiki/MacOS#Install) and confirm that `stitcher -h` works at the very least
+ * Follow the [install instructions](https://github.com/GENI-NSF/geni-tools/wiki/MacOS#install) and confirm that `stitcher -h` works at the very least
 * Un-install
  * In finder, drag `omniTools` to the trash
 * Eject the `omniTools` dmg

--- a/doc/IssuingReleases.md
+++ b/doc/IssuingReleases.md
@@ -166,9 +166,9 @@ See EG: https://github.com/GENI-NSF/geni-tools/commit/f757f53e20451194438b1b7d32
 * `agg_nick_cache.base`: This should reference the just-released version# and date
 
 # Update wiki pages
-Update the geni-tools wiki pages to describe the new release, and point to the new release for downloads.
+Update the geni-tools wiki pages to describe the new release, and point to the new release for downloads. These instructions reference the old trac wiki pages. New pages are at https://github.com/GENI-NSF/geni-tools/wiki and should be similarly named and edited.
 
-Docs are currently at http://trac.gpolab.bbn.com/gcf/
+(Old) Docs are at http://trac.gpolab.bbn.com/gcf/
 
 * Home page: Update release number and date, and the browse source link, and links to downloading the release
 * `GettingGcf`: Update 2 links for downloading the release
@@ -181,7 +181,10 @@ Docs are currently at http://trac.gpolab.bbn.com/gcf/
 * `GcfQuickStart`: Update with `README-gcf.txt
 * `Windows`: Update version numbers, download links
 * `MacOS`: Update version numbers, download links
-* `agg_nick_cache`: Update with latest `agg_nick_cache.base` from the develop branch, where you updated the release date for this release
+* `agg_nick_cache`: This file lives on Github only (see https://raw.githubusercontent.com/wiki/GENI-NSF/geni-tools/agg_nick_cache). Update with latest `agg_nick_cache.base` from the develop branch, where you updated the release date for this release
+ * To edit this on Github:
+  * Check out the geni-tools wiki on your machine.
+  * Edit the file and commit it to git, pushing to origin/master as usual.
 * Close existing milestone
 * Create new milestone
 * Re target any remaining issues that were not be fixed for this release to the next release.

--- a/mac_install/INSTALL.txt
+++ b/mac_install/INSTALL.txt
@@ -23,4 +23,4 @@ UNINSTALLING OMNI TOOLS
 
 
 READMEs and associated documentation are installed in
-/Applications/omniTools-2.10, or available online: http://trac.gpolab.bbn.com/gcf
+/Applications/omniTools-2.10, or available online: https://github.com/GENI-NSF/geni-tools/wiki

--- a/omni_config.sample
+++ b/omni_config.sample
@@ -36,7 +36,7 @@
 # Specify the latest version of Omni released, and a message
 # Expected format is "#,Message" EG: "2.8,Omni 2.8 was release 2/1/2015". No commas in the message.
 # If a newer version is available, Omni will log a message at INFO level.
-# latest_omni_version=2.7,Omni 2.7 was released 1/14/2014. See http://trac.gpolab.bbn.com/gcf
+# latest_omni_version=2.7,Omni 2.7 was released 1/14/2014. See https://github.com/GENI-NSF/geni-tools/wiki
 
 [omni]
 # The default control framework for omni to use.
@@ -79,7 +79,7 @@ default_cf = my_gcf
 
 #------AM nicknames
 # Omni defines a standard set of aggregate nicknames. These are retrieved periodically
-# from http://trac.gpolab.bbn.com/gcf/raw-attachment/wiki/Omni/agg_nick_cache
+# from https://raw.githubusercontent.com/wiki/GENI-NSF/geni-tools/agg_nick_cache
 # Put your custom aggregate nicknames here. 
 # To see all available nicknames try: omni.py nicknames
 #

--- a/src/gcf/oscript.py
+++ b/src/gcf/oscript.py
@@ -1045,7 +1045,7 @@ def getParser():
  \t\t\t nicknames \n\
  \t\t\t print_sliver_expirations <slicename> \n\
 \n\t See README-omni.txt for details.\n\
-\t And see the Omni website at http://trac.gpolab.bbn.com/gcf"
+\t And see the Omni website at https://github.com/GENI-NSF/geni-tools/wiki."
 
     parser = optparse.OptionParser(usage=usage, version="%prog: " + getOmniVersion())
 
@@ -1186,7 +1186,7 @@ def getParser():
                       default="~/.gcf/agg_nick_cache",
                       help="File where AggNick info will be cached, default is %default")
     angroup.add_option("--AggNickDefinitiveLocation", dest='aggNickDefinitiveLocation',
-                      default="http://trac.gpolab.bbn.com/gcf/raw-attachment/wiki/Omni/agg_nick_cache",
+                      default="https://raw.githubusercontent.com/wiki/GENI-NSF/geni-tools/agg_nick_cache",
                       help="Website with latest agg_nick_cache, default is %default. To force Omni to read this cache, delete your local AggNickCache or use --NoAggNickCache.")
     parser.add_option_group( angroup )
 

--- a/windows_install/infoAfterFile.rtf
+++ b/windows_install/infoAfterFile.rtf
@@ -15,12 +15,12 @@
 \ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \fs24\lang1033\langfe1033\cgrid\langnp1033\langfenp1033 {\b\f1\insrsid16532973 Configuration
 \par }{\f1\fs20\insrsid16532973 
 \par For instructions on how to }{\f1\fs20\insrsid16532973 Configure}{\f1\fs20\insrsid16532973  omni, please see:
-\par http://trac.gpolab.bbn.com/gcf/wiki/}{\f1\fs20\insrsid16532973 Windows}{\f1\fs20\insrsid16532973 
+\par https://github.com/GENI-NSF/geni-tools/wiki}{\f1\fs20\insrsid16532973 Windows}{\f1\fs20\insrsid16532973 
 \par 
 \par }{\b\f1\insrsid16532973 More Information
 \par }{\f1\fs20\insrsid16532973 
 \par For more information about omni, please see the gcf/omni wiki:
-\par http://trac.gpolab.bbn.com/gcf/wiki
+\par https://github.com/GENI-NSF/geni-tools/wiki
 \par 
 \par Or ask questions on the GENI Users mailing list: 
 \par https://groups.google.com/forum/#!forum/geni-users

--- a/windows_install/package_builder.iss
+++ b/windows_install/package_builder.iss
@@ -13,8 +13,8 @@ UsePreviousAppDir=false
 [Run]
 Filename: {app}\install.vbs; Flags: shellexec
 [Icons]
-Name: {group}\Documentation; Filename: http://trac.gpolab.bbn.com/gcf/wiki; Comment: omni wiki
-Name: {group}\How To Configure omniTools-2.10; Filename: http://trac.gpolab.bbn.com/gcf/wiki/Windows; Comment: Instructions for configuring omniTools-2.10
+Name: {group}\Documentation; Filename: https://github.com/GENI-NSF/geni-tools/wiki; Comment: omni wiki
+Name: {group}\How To Configure omniTools-2.10; Filename: https://github.com/GENI-NSF/geni-tools/wiki/Windows; Comment: Instructions for configuring omniTools-2.10
 Name: {group}\Disclaimer; Filename: {app}\LICENSE.TXT
 Name: {group}\{cm:UninstallProgram, omniTools-2.10}; Filename: {uninstallexe}
 [Files]


### PR DESCRIPTION
Addresses issue #814: Change many references to wiki pages on trac.gpolab.bbn.com to github.

Additionally, move the canonical agg_nick_cache to a github page.
