### PR TITLE
issue #879: when merging links on a manifest, allow merging non stitched links

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -41,6 +41,8 @@ gcf 2.10:
     in some cases. (#839)
   * AL2S supports speaks for. Don't exit if using speaksfor and AL2S. (#834)
   * Treat new generic ProtoGENI mapper error code (28) as fatal. (#861)
+  * Fix combining manifests where link is multi AM but not stitched. (#879)
+   * Thanks to Hussam Nasir
 
  * omni-configure
   * Modify omni-configure to support multi-user systems (#843)

--- a/src/gcf/omnilib/stitch/ManifestRSpecCombiner.py
+++ b/src/gcf/omnilib/stitch/ManifestRSpecCombiner.py
@@ -552,8 +552,8 @@ class ManifestRSpecCombiner:
                             break
                         # Get the link with a sliverid and the right client_id
                         if str(link2.getAttribute(CLIENT_ID)) == client_id and \
-                                link2.hasAttribute(VLANTAG):
-                            self.logger.debug("Found AM %s link '%s' that has vlantag '%s'", agg.urn, client_id, link2.getAttribute('vlantag'))
+                           (link2.hasAttribute(VLANTAG) or link2.hasAttribute(SLIVER_ID)):
+                            self.logger.debug("Found AM %s link '%s' that has sliverid '%s' and possibly a vlantag '%s'", agg.urn, client_id,link2.hasAttribute(SLIVER_ID), link2.getAttribute(VLANTAG))
                             if needSwap:
                                 self.logger.debug("Will swap link in template with this element")
                                 link2Clone = link2.cloneNode(True)


### PR DESCRIPTION
Old code only merged a link that had a VLAN. Now allow it to have a sliver_id to indicate it is the proper manifest, so we can merge EGRE or GRE links. Thanks, Hussam.