### PR TITLE
Move aggcache to master branch and fix urlretrieve

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -23,6 +23,8 @@ gcf 2.10:
     no longer means just return that file. Instead, that file will be
     ignored and, if you specify `-o`, replaced. (#868)
   * Moved canonical `agg_nick_cache` location to Github. (#814)
+  * Use `urllib2.urlopen` instead of `urllib.urlretrieve` to avoid bad
+    interaction with M2Crypto. (#881)
 
  * Stitcher
   * Catch expiration too great errors from PG AMs and quit. (#828)

--- a/README-omni.txt
+++ b/README-omni.txt
@@ -854,7 +854,7 @@ Options:
                         ~/.gcf/agg_nick_cache
     --AggNickDefinitiveLocation=AGGNICKDEFINITIVELOCATION
                         Website with latest agg_nick_cache, default is
-                        https://raw.githubusercontent.com/wiki/GENI-NSF/geni-
+                        https://raw.githubusercontent.com/GENI-NSF/geni-
                         tools/master/agg_nick_cache.base. To force Omni to
                         read this cache, delete your local AggNickCache or use
                         --NoAggNickCache.

--- a/README-omni.txt
+++ b/README-omni.txt
@@ -59,6 +59,8 @@ New in v2.10:
    no longer means just return that file. Instead, that file will be
    ignored and, if you specify `-o`, replaced. (#868)
  * Moved canonical `agg_nick_cache` location to Github. (#814)
+ * Use `urllib2.urlopen` instead of `urllib.urlretrieve` to avoid bad
+   interaction with M2Crypto. (#881)
 
 New in v2.9:
  * If `sliverstatus` fails in a way that indicates there are no local resources,

--- a/README-omni.txt
+++ b/README-omni.txt
@@ -853,8 +853,8 @@ Options:
     --AggNickDefinitiveLocation=AGGNICKDEFINITIVELOCATION
                         Website with latest agg_nick_cache, default is
                         https://raw.githubusercontent.com/wiki/GENI-NSF/geni-
-                        tools/agg_nick_cache. To force Omni to read this
-                        cache, delete your local AggNickCache or use
+                        tools/master/agg_nick_cache.base. To force Omni to
+                        read this cache, delete your local AggNickCache or use
                         --NoAggNickCache.
 
   For Developers / Advanced Users:

--- a/acceptance_tests/AM_API/README-accept-AMAPI.txt
+++ b/acceptance_tests/AM_API/README-accept-AMAPI.txt
@@ -592,9 +592,9 @@ Options:
                         ~/.gcf/agg_nick_cache
     --AggNickDefinitiveLocation=AGGNICKDEFINITIVELOCATION
                         Website with latest agg_nick_cache, default is
-                        https://raw.githubusercontent.com/wiki/GENI-NSF/geni-
-                        tools/agg_nick_cache. To force Omni to read this
-                        cache, delete your local AggNickCache or use
+                        https://raw.githubusercontent.com/GENI-NSF/geni-
+                        tools/master/agg_nick_cache.base. To force Omni to
+                        read this cache, delete your local AggNickCache or use
                         --NoAggNickCache.
 
   For Developers / Advanced Users:

--- a/agg_nick_cache.base
+++ b/agg_nick_cache.base
@@ -1,5 +1,6 @@
 ### DO NOT MODIFY THIS FILE BY HAND ###
-# This file lives at: https://raw.githubusercontent.com/wiki/GENI-NSF/geni-tools/agg_nick_cache
+# This file lives at: https://raw.githubusercontent.com/GENI-NSF/geni-tools/master/agg_nick_cache.base
+# - the master branch of the geni-tools Github repository
 # Last updated on December 9, 2015
 
 [omni_defaults]

--- a/doc/IssuingReleases.md
+++ b/doc/IssuingReleases.md
@@ -181,10 +181,7 @@ Update the geni-tools wiki pages to describe the new release, and point to the n
 * `GcfQuickStart`: Update with `README-gcf.txt
 * `Windows`: Update version numbers, download links
 * `MacOS`: Update version numbers, download links
-* `agg_nick_cache`: This file lives on Github only (see https://raw.githubusercontent.com/wiki/GENI-NSF/geni-tools/agg_nick_cache). Update with latest `agg_nick_cache.base` from the develop branch, where you updated the release date for this release
- * To edit this on Github:
-  * Check out the geni-tools wiki on your machine.
-  * Edit the file and commit it to git, pushing to origin/master as usual.
+* `agg_nick_cache`: This file lives on Github now (see https://raw.githubusercontent.com/GENI-NSF/geni-tools/master/agg_nick_cache.base). After the release, update the version on the master branch in git to list the current Omni version / release date.
 * Close existing milestone
 * Create new milestone
 * Re target any remaining issues that were not be fixed for this release to the next release.

--- a/omni_config.sample
+++ b/omni_config.sample
@@ -79,7 +79,7 @@ default_cf = my_gcf
 
 #------AM nicknames
 # Omni defines a standard set of aggregate nicknames. These are retrieved periodically
-# from https://raw.githubusercontent.com/wiki/GENI-NSF/geni-tools/agg_nick_cache
+# from https://raw.githubusercontent.com/GENI-NSF/geni-tools/master/agg_nick_cache.base
 # Put your custom aggregate nicknames here. 
 # To see all available nicknames try: omni.py nicknames
 #

--- a/src/gcf/oscript.py
+++ b/src/gcf/oscript.py
@@ -486,6 +486,7 @@ def update_agg_nick_cache( opts, logger ):
         directory = os.path.dirname(opts.aggNickCacheName)
         if not os.path.exists( directory ):
             os.makedirs( directory )
+        logger.debug("Attempting to refresh agg_nick_cache from %s...", opts.aggNickDefinitiveLocation)
         urllib.urlretrieve( opts.aggNickDefinitiveLocation, tmpcache )
         good = False
         if os.path.exists(tmpcache) and os.path.getsize(tmpcache) > 0:

--- a/src/gcf/oscript.py
+++ b/src/gcf/oscript.py
@@ -1186,7 +1186,7 @@ def getParser():
                       default="~/.gcf/agg_nick_cache",
                       help="File where AggNick info will be cached, default is %default")
     angroup.add_option("--AggNickDefinitiveLocation", dest='aggNickDefinitiveLocation',
-                      default="https://raw.githubusercontent.com/wiki/GENI-NSF/geni-tools/agg_nick_cache",
+                      default="https://raw.githubusercontent.com/GENI-NSF/geni-tools/master/agg_nick_cache.base",
                       help="Website with latest agg_nick_cache, default is %default. To force Omni to read this cache, delete your local AggNickCache or use --NoAggNickCache.")
     parser.add_option_group( angroup )
 


### PR DESCRIPTION
Addresses issues #814 and issue #881.

Make the aggcache come directly from the master branch on github - one less file move.

AND, fix the fetching of the cache to use `urllib2.urlopen` instead of `urllib.urlretrieve` as the latter gets screwed up by the import of `M2Crypto`.
