### PR TITLE
Remove bogus check for 'rspec' tag

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 # Note: keep this file in wiki format for easy pasting to the gcf wiki
 
 gcf 2.11:
+ * Remove bogus check for rspec tag (#885)
 
 gcf 2.10:
  * Changed references to trac.gpolab.bbn.com to point to Github.

--- a/src/gcf/geni/util/rspec_util.py
+++ b/src/gcf/geni/util/rspec_util.py
@@ -329,14 +329,11 @@ def is_rspec_string( rspec, rspec_namespace=None, rspec_schema=None,
     if not is_wellformed_xml( rspec, logger ):
         return False
     
-    # (2) Check if rspec is a valid XML document
-    #   (a) a snippet of XML starting with <rspec>, or
-    #   (b) a snippet of XML starting with <resv_rspec>
-    if ('<rspec' not in rspec) and \
-        ('<resv_rspec' not in rspec):
-        if logger:
-            logger.debug("RSpec string invalid: no rspec element")
-        return False
+    # (2) This was a textual check for an 'rspec' element which is
+    #     bogus because it doesn't take namespaces into account
+    #     and is easily fooled. Replace this with a proper check
+    #     that the outermost tag is 'rspec' and be sensitive to
+    #     XML namespaces.
 
     # (3) Validate rspec against schema
     if rspec_namespace and rspec_schema:


### PR DESCRIPTION
The check for an rspec tag is bogus because it does not take XML
namespaces into account. It can cause erroneous errors on valid
rspecs. Remove the check until a proper check can be put in place.

Fixes #885
