### PR TITLE
Fix SFA credential use of strip on refid in issue #890

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@
 
 gcf 2.11:
  * Remove bogus check for rspec tag (#885)
+ * Properly remove prefix from signature refid in SFA credentials. (#890)
 
 gcf 2.10:
  * Changed references to trac.gpolab.bbn.com to point to Github.

--- a/src/gcf/sfa/trust/credential.py
+++ b/src/gcf/sfa/trust/credential.py
@@ -183,20 +183,26 @@ class Signature(object):
         self.gid = gid
 
     def decode(self):
+        # Helper function to pull characters off the front of a string if present
+        def remove_prefix(text, prefix):
+            if text and prefix and text.startswith(prefix):
+                return text[len(prefix):]
+            return text
+
         try:
             doc = parseString(self.xml)
         except ExpatError,e:
             logger.log_exc ("Failed to parse credential, %s"%self.xml)
             raise
         sig = doc.getElementsByTagName("Signature")[0]
-        ref_id = sig.getAttribute("xml:id").strip().strip("Sig_")
+        ref_id = remove_prefix(sig.getAttribute("xml:id").strip(), "Sig_")
         # The xml:id tag is optional, and could be in a 
         # Reference xml:id or Reference UID sub element instead
         if not ref_id or ref_id == '':
             reference = sig.getElementsByTagName('Reference')[0]
-            ref_id = reference.getAttribute('xml:id').strip().strip('Sig_')
+            ref_id = remove_prefix(reference.getAttribute('xml:id').strip(), 'Sig_')
             if not ref_id or ref_id == '':
-                ref_id = reference.getAttribute('URI').strip().strip('#')
+                ref_id = remove_prefix(reference.getAttribute('URI').strip(), '#')
         self.set_refid(ref_id)
         keyinfos = sig.getElementsByTagName("X509Data")
         gids = None


### PR DESCRIPTION
Fir the use of `strip()` to extract the `refid` in credentials in the SFA's `credential.py`. Fixes issue #890 