### PR TITLE
Remove InstaGENI FOAM aggregates

### DIFF
--- a/agg_nick_cache.base
+++ b/agg_nick_cache.base
@@ -112,7 +112,7 @@ renci-eg-of2=urn:publicid:IDN+openflow:foam:rci-hn.exogeni.net+authority+am,http
 # ExoSM
 eg-sm=urn:publicid:IDN+exogeni.net+authority+am,https://geni.renci.org:11443/orca/xmlrpc
 
-# InstaGENI AMs, including OpenFlow InstaGENI AMs
+# InstaGENI AMs
 ig-utah=urn:publicid:IDN+utah.geniracks.net+authority+cm,https://boss.utah.geniracks.net:12369/protogeni/xmlrpc/am/2.0
 ig-utah1=urn:publicid:IDN+utah.geniracks.net+authority+cm,https://boss.utah.geniracks.net:12369/protogeni/xmlrpc/am/1.0
 ig-utah2=urn:publicid:IDN+utah.geniracks.net+authority+cm,https://boss.utah.geniracks.net:12369/protogeni/xmlrpc/am/2.0
@@ -121,34 +121,24 @@ utah-ig=urn:publicid:IDN+utah.geniracks.net+authority+cm,https://boss.utah.genir
 utah1-ig=urn:publicid:IDN+utah.geniracks.net+authority+cm,https://boss.utah.geniracks.net:12369/protogeni/xmlrpc/am/1.0
 utah2-ig=urn:publicid:IDN+utah.geniracks.net+authority+cm,https://boss.utah.geniracks.net:12369/protogeni/xmlrpc/am/2.0
 utah3-ig=urn:publicid:IDN+utah.geniracks.net+authority+cm,https://boss.utah.geniracks.net:12369/protogeni/xmlrpc/am/3.0
-ig-of-utah=urn:publicid:IDN+openflow:foam:ig-utah+authority+am,https://foam.utah.geniracks.net:3626/foam/gapi/2
-utah-ig-of=urn:publicid:IDN+openflow:foam:ig-utah+authority+am,https://foam.utah.geniracks.net:3626/foam/gapi/2
-utah-ig-of1=urn:publicid:IDN+openflow:foam:ig-utah+authority+am,https://foam.utah.geniracks.net:3626/foam/gapi/1
-utah-ig-of2=urn:publicid:IDN+openflow:foam:ig-utah+authority+am,https://foam.utah.geniracks.net:3626/foam/gapi/2
 
 gpo-ig=urn:publicid:IDN+instageni.gpolab.bbn.com+authority+cm,https://boss.instageni.gpolab.bbn.com:12369/protogeni/xmlrpc/am/2.0
 gpo1-ig=urn:publicid:IDN+instageni.gpolab.bbn.com+authority+cm,https://boss.instageni.gpolab.bbn.com:12369/protogeni/xmlrpc/am/1.0
 gpo2-ig=urn:publicid:IDN+instageni.gpolab.bbn.com+authority+cm,https://boss.instageni.gpolab.bbn.com:12369/protogeni/xmlrpc/am/2.0
 gpo3-ig=urn:publicid:IDN+instageni.gpolab.bbn.com+authority+cm,https://boss.instageni.gpolab.bbn.com:12369/protogeni/xmlrpc/am/3.0
-gpo-ig-of=urn:publicid:IDN+openflow:foam:foam.instageni.gpolab.bbn.com+authority+am,https://foam.instageni.gpolab.bbn.com:3626/foam/gapi/2
-gpo-ig-of1=urn:publicid:IDN+openflow:foam:foam.instageni.gpolab.bbn.com+authority+am,https://foam.instageni.gpolab.bbn.com:3626/foam/gapi/1
-gpo-ig-of2=urn:publicid:IDN+openflow:foam:foam.instageni.gpolab.bbn.com+authority+am,https://foam.instageni.gpolab.bbn.com:3626/foam/gapi/2
 ig-gpo=urn:publicid:IDN+instageni.gpolab.bbn.com+authority+cm,https://boss.instageni.gpolab.bbn.com:12369/protogeni/xmlrpc/am/2.0
 ig-gpo1=urn:publicid:IDN+instageni.gpolab.bbn.com+authority+cm,https://boss.instageni.gpolab.bbn.com:12369/protogeni/xmlrpc/am/1.0
 ig-gpo2=urn:publicid:IDN+instageni.gpolab.bbn.com+authority+cm,https://boss.instageni.gpolab.bbn.com:12369/protogeni/xmlrpc/am/2.0
 ig-gpo3=urn:publicid:IDN+instageni.gpolab.bbn.com+authority+cm,https://boss.instageni.gpolab.bbn.com:12369/protogeni/xmlrpc/am/3.0
-ig-of-gpo=urn:publicid:IDN+openflow:foam:foam.instageni.gpolab.bbn.com+authority+am,https://foam.instageni.gpolab.bbn.com:3626/foam/gapi/2
 ig-bbn=urn:publicid:IDN+instageni.gpolab.bbn.com+authority+cm,https://boss.instageni.gpolab.bbn.com:12369/protogeni/xmlrpc/am/2.0
 ig-bbn1=urn:publicid:IDN+instageni.gpolab.bbn.com+authority+cm,https://boss.instageni.gpolab.bbn.com:12369/protogeni/xmlrpc/am/1.0
 ig-bbn2=urn:publicid:IDN+instageni.gpolab.bbn.com+authority+cm,https://boss.instageni.gpolab.bbn.com:12369/protogeni/xmlrpc/am/2.0
 ig-bbn3=urn:publicid:IDN+instageni.gpolab.bbn.com+authority+cm,https://boss.instageni.gpolab.bbn.com:12369/protogeni/xmlrpc/am/3.0
-ig-of-bbn=urn:publicid:IDN+openflow:foam:foam.instageni.gpolab.bbn.com+authority+am,https://foam.instageni.gpolab.bbn.com:3626/foam/gapi/2
 
 ig-ky=urn:publicid:IDN+lan.sdn.uky.edu+authority+cm,https://boss.lan.sdn.uky.edu:12369/protogeni/xmlrpc/am/2.0
 ig-ky1=urn:publicid:IDN+lan.sdn.uky.edu+authority+cm,https://boss.lan.sdn.uky.edu:12369/protogeni/xmlrpc/am/1.0
 ig-ky2=urn:publicid:IDN+lan.sdn.uky.edu+authority+cm,https://boss.lan.sdn.uky.edu:12369/protogeni/xmlrpc/am/2.0
 ig-ky3=urn:publicid:IDN+lan.sdn.uky.edu+authority+cm,https://boss.lan.sdn.uky.edu:12369/protogeni/xmlrpc/am/3.0
-ig-of-ky=urn:publicid:IDN+openflow:foam:foam.lan.sdn.uky.edu+authority+am,https://foam.lan.sdn.uky.edu:3626/foam/gapi/2
 
 ig-uky=urn:publicid:IDN+lan.sdn.uky.edu+authority+cm,https://boss.lan.sdn.uky.edu:12369/protogeni/xmlrpc/am/2.0
 ig-uky1=urn:publicid:IDN+lan.sdn.uky.edu+authority+cm,https://boss.lan.sdn.uky.edu:12369/protogeni/xmlrpc/am/1.0
@@ -158,10 +148,6 @@ uky-ig=urn:publicid:IDN+lan.sdn.uky.edu+authority+cm,https://boss.lan.sdn.uky.ed
 uky1-ig=urn:publicid:IDN+lan.sdn.uky.edu+authority+cm,https://boss.lan.sdn.uky.edu:12369/protogeni/xmlrpc/am/1.0
 uky2-ig=urn:publicid:IDN+lan.sdn.uky.edu+authority+cm,https://boss.lan.sdn.uky.edu:12369/protogeni/xmlrpc/am/2.0
 uky3-ig=urn:publicid:IDN+lan.sdn.uky.edu+authority+cm,https://boss.lan.sdn.uky.edu:12369/protogeni/xmlrpc/am/3.0
-ig-of-uky=urn:publicid:IDN+openflow:foam:foam.lan.sdn.uky.edu+authority+am,https://foam.lan.sdn.uky.edu:3626/foam/gapi/2
-uky-ig-of=urn:publicid:IDN+openflow:foam:foam.lan.sdn.uky.edu+authority+am,https://foam.lan.sdn.uky.edu:3626/foam/gapi/2
-uky-ig-of1=urn:publicid:IDN+openflow:foam:foam.lan.sdn.uky.edu+authority+am,https://foam.lan.sdn.uky.edu:3626/foam/gapi/1
-uky-ig-of2=urn:publicid:IDN+openflow:foam:foam.lan.sdn.uky.edu+authority+am,https://foam.lan.sdn.uky.edu:3626/foam/gapi/2
 
 ig-kettering=urn:publicid:IDN+geni.kettering.edu+authority+cm,https://geni.kettering.edu:12369/protogeni/xmlrpc/am
 ig-kettering1=urn:publicid:IDN+geni.kettering.edu+authority+cm,https://geni.kettering.edu:12369/protogeni/xmlrpc/am/1.0
@@ -171,10 +157,6 @@ kettering-ig=urn:publicid:IDN+geni.kettering.edu+authority+cm,https://geni.kette
 kettering1-ig=urn:publicid:IDN+geni.kettering.edu+authority+cm,https://geni.kettering.edu:12369/protogeni/xmlrpc/am/1.0
 kettering2-ig=urn:publicid:IDN+geni.kettering.edu+authority+cm,https://geni.kettering.edu:12369/protogeni/xmlrpc/am/2.0
 kettering3-ig=urn:publicid:IDN+geni.kettering.edu+authority+cm,https://geni.kettering.edu:12369/protogeni/xmlrpc/am/3.0
-ig-of-kettering=urn:publicid:IDN+openflow:foam:foam.geni.kettering.edu+authority+am,https://foam.geni.kettering.edu:3626/foam/gapi/2
-kettering-ig-of=urn:publicid:IDN+openflow:foam:foam.geni.kettering.edu+authority+am,https://foam.geni.kettering.edu:3626/foam/gapi/2
-kettering-ig-of1=urn:publicid:IDN+openflow:foam:foam.geni.kettering.edu+authority+am,https://foam.geni.kettering.edu:3626/foam/gapi/1
-kettering-ig-of2=urn:publicid:IDN+openflow:foam:foam.geni.kettering.edu+authority+am,https://foam.geni.kettering.edu:3626/foam/gapi/2
 
 ig-northwestern=urn:publicid:IDN+instageni.northwestern.edu+authority+cm,https://instageni.northwestern.edu:12369/protogeni/xmlrpc/am
 ig-northwestern1=urn:publicid:IDN+instageni.northwestern.edu+authority+cm,https://instageni.northwestern.edu:12369/protogeni/xmlrpc/am/1.0
@@ -184,10 +166,6 @@ northwestern-ig=urn:publicid:IDN+instageni.northwestern.edu+authority+cm,https:/
 northwestern1-ig=urn:publicid:IDN+instageni.northwestern.edu+authority+cm,https://instageni.northwestern.edu:12369/protogeni/xmlrpc/am/1.0
 northwestern2-ig=urn:publicid:IDN+instageni.northwestern.edu+authority+cm,https://instageni.northwestern.edu:12369/protogeni/xmlrpc/am/2.0
 northwestern3-ig=urn:publicid:IDN+instageni.northwestern.edu+authority+cm,https://instageni.northwestern.edu:12369/protogeni/xmlrpc/am/3.0
-ig-of-northwestern=urn:publicid:IDN+openflow:foam:foam.instageni.northwestern.edu+authority+am,https://foam.instageni.northwestern.edu:3626/foam/gapi/2
-northwestern-ig-of=urn:publicid:IDN+openflow:foam:foam.instageni.northwestern.edu+authority+am,https://foam.instageni.northwestern.edu:3626/foam/gapi/2
-northwestern-ig-of1=urn:publicid:IDN+openflow:foam:foam.instageni.northwestern.edu+authority+am,https://foam.instageni.northwestern.edu:3626/foam/gapi/1
-northwestern-ig-of2=urn:publicid:IDN+openflow:foam:foam.instageni.northwestern.edu+authority+am,https://foam.instageni.northwestern.edu:3626/foam/gapi/2
 
 # ============================================
 # Utah Downtown Data Center InstaGENI Rack
@@ -196,9 +174,6 @@ utahddc-ig=urn:publicid:IDN+utahddc.geniracks.net+authority+cm,https://boss.utah
 utahddc-ig1=urn:publicid:IDN+utahddc.geniracks.net+authority+cm,https://boss.utahddc.geniracks.net:12369/protogeni/xmlrpc/am/1.0
 utahddc-ig2=urn:publicid:IDN+utahddc.geniracks.net+authority+cm,https://boss.utahddc.geniracks.net:12369/protogeni/xmlrpc/am/2.0
 utahddc-ig3=urn:publicid:IDN+utahddc.geniracks.net+authority+cm,https://boss.utahddc.geniracks.net:12369/protogeni/xmlrpc/am/3.0
-utahddc-ig-of=urn:publicid:IDN+openflow:foam:foam.utahddc.geniracks.net+authority+am,https://foam.utahddc.geniracks.net:3626/foam/gapi/2
-utahddc-ig-of1=urn:publicid:IDN+openflow:foam:foam.utahddc.geniracks.net+authority+am,https://foam.utahddc.geniracks.net:3626/foam/gapi/1
-utahddc-ig-of2=urn:publicid:IDN+openflow:foam:foam.utahddc.geniracks.net+authority+am,https://foam.utahddc.geniracks.net:3626/foam/gapi/2
 
 # ============================================
 # Georgia Tech InstaGENI Rack
@@ -207,9 +182,6 @@ gatech-ig=urn:publicid:IDN+instageni.rnoc.gatech.edu+authority+cm,https://instag
 gatech-ig1=urn:publicid:IDN+instageni.rnoc.gatech.edu+authority+cm,https://instageni.rnoc.gatech.edu:12369/protogeni/xmlrpc/am/1.0
 gatech-ig2=urn:publicid:IDN+instageni.rnoc.gatech.edu+authority+cm,https://instageni.rnoc.gatech.edu:12369/protogeni/xmlrpc/am/2.0
 gatech-ig3=urn:publicid:IDN+instageni.rnoc.gatech.edu+authority+cm,https://instageni.rnoc.gatech.edu:12369/protogeni/xmlrpc/am/3.0
-gatech-ig-of=urn:publicid:IDN+openflow:foam:foam.instageni.rnoc.gatech.edu+authority+am,https://foam.instageni.rnoc.gatech.edu:3626/foam/gapi/2
-gatech-ig-of1=urn:publicid:IDN+openflow:foam:foam.instageni.rnoc.gatech.edu+authority+am,https://foam.instageni.rnoc.gatech.edu:3626/foam/gapi/1
-gatech-ig-of2=urn:publicid:IDN+openflow:foam:foam.instageni.rnoc.gatech.edu+authority+am,https://foam.instageni.rnoc.gatech.edu:3626/foam/gapi/2
 
 # ============================================
 # NYSERNet InstaGENI Rack
@@ -218,9 +190,6 @@ nysernet-ig=urn:publicid:IDN+instageni.nysernet.org+authority+cm,https://instage
 nysernet-ig1=urn:publicid:IDN+instageni.nysernet.org+authority+cm,https://instageni.nysernet.org:12369/protogeni/xmlrpc/am/1.0
 nysernet-ig2=urn:publicid:IDN+instageni.nysernet.org+authority+cm,https://instageni.nysernet.org:12369/protogeni/xmlrpc/am/2.0
 nysernet-ig3=urn:publicid:IDN+instageni.nysernet.org+authority+cm,https://instageni.nysernet.org:12369/protogeni/xmlrpc/am/3.0
-nysernet-ig-of=urn:publicid:IDN+openflow:foam:foam.instageni.nysernet.org+authority+am,https://foam.instageni.nysernet.org:3626/foam/gapi/2
-nysernet-ig-of1=urn:publicid:IDN+openflow:foam:foam.instageni.nysernet.org+authority+am,https://foam.instageni.nysernet.org:3626/foam/gapi/1
-nysernet-ig-of2=urn:publicid:IDN+openflow:foam:foam.instageni.nysernet.org+authority+am,https://foam.instageni.nysernet.org:3626/foam/gapi/2
 
 # ============================================
 # Southern Crossroads (SoX) OpenFlow
@@ -243,9 +212,6 @@ max-ig=urn:publicid:IDN+instageni.maxgigapop.net+authority+cm,https://instageni.
 max-ig1=urn:publicid:IDN+instageni.maxgigapop.net+authority+cm,https://instageni.maxgigapop.net:12369/protogeni/xmlrpc/am/1.0
 max-ig2=urn:publicid:IDN+instageni.maxgigapop.net+authority+cm,https://instageni.maxgigapop.net:12369/protogeni/xmlrpc/am/2.0
 max-ig3=urn:publicid:IDN+instageni.maxgigapop.net+authority+cm,https://instageni.maxgigapop.net:12369/protogeni/xmlrpc/am/3.0
-max-ig-of=urn:publicid:IDN+openflow:foam:foam.instageni.maxgigapop.net+authority+am,https://foam.instageni.maxgigapop.net:3626/foam/gapi/2
-max-ig-of1=urn:publicid:IDN+openflow:foam:foam.instageni.maxgigapop.net+authority+am,https://foam.instageni.maxgigapop.net:3626/foam/gapi/1
-max-ig-of2=urn:publicid:IDN+openflow:foam:foam.instageni.maxgigapop.net+authority+am,https://foam.instageni.maxgigapop.net:3626/foam/gapi/2
 
 # ============================================
 # Clemson InstaGENI Rack
@@ -254,9 +220,6 @@ clemson-ig=urn:publicid:IDN+instageni.clemson.edu+authority+cm,https://instageni
 clemson-ig1=urn:publicid:IDN+instageni.clemson.edu+authority+cm,https://instageni.clemson.edu:12369/protogeni/xmlrpc/am/1.0
 clemson-ig2=urn:publicid:IDN+instageni.clemson.edu+authority+cm,https://instageni.clemson.edu:12369/protogeni/xmlrpc/am/2.0
 clemson-ig3=urn:publicid:IDN+instageni.clemson.edu+authority+cm,https://instageni.clemson.edu:12369/protogeni/xmlrpc/am/3.0
-clemson-ig-of=urn:publicid:IDN+openflow:foam:foam.instageni.clemson.edu+authority+am,https://foam.instageni.clemson.edu:3626/foam/gapi/2
-clemson-ig-of1=urn:publicid:IDN+openflow:foam:foam.instageni.clemson.edu+authority+am,https://foam.instageni.clemson.edu:3626/foam/gapi/1
-clemson-ig-of2=urn:publicid:IDN+openflow:foam:foam.instageni.clemson.edu+authority+am,https://foam.instageni.clemson.edu:3626/foam/gapi/2
 
 # ============================================
 # University of Missouri-Columbia InstaGENI Rack
@@ -265,9 +228,6 @@ missouri-ig=urn:publicid:IDN+instageni.rnet.missouri.edu+authority+cm,https://in
 missouri-ig1=urn:publicid:IDN+instageni.rnet.missouri.edu+authority+cm,https://instageni.rnet.missouri.edu:12369/protogeni/xmlrpc/am/1.0
 missouri-ig2=urn:publicid:IDN+instageni.rnet.missouri.edu+authority+cm,https://instageni.rnet.missouri.edu:12369/protogeni/xmlrpc/am/2.0
 missouri-ig3=urn:publicid:IDN+instageni.rnet.missouri.edu+authority+cm,https://instageni.rnet.missouri.edu:12369/protogeni/xmlrpc/am/3.0
-missouri-ig-of=urn:publicid:IDN+openflow:foam:foam.instageni.rnet.missouri.edu+authority+am,https://foam.instageni.rnet.missouri.edu:3626/foam/gapi/2
-missouri-ig-of1=urn:publicid:IDN+openflow:foam:foam.instageni.rnet.missouri.edu+authority+am,https://foam.instageni.rnet.missouri.edu:3626/foam/gapi/1
-missouri-ig-of2=urn:publicid:IDN+openflow:foam:foam.instageni.rnet.missouri.edu+authority+am,https://foam.instageni.rnet.missouri.edu:3626/foam/gapi/2
 
 # ============================================
 # NYU InstaGENI Rack
@@ -276,9 +236,6 @@ nyu-ig=urn:publicid:IDN+genirack.nyu.edu+authority+cm,https://genirack.nyu.edu:1
 nyu-ig1=urn:publicid:IDN+genirack.nyu.edu+authority+cm,https://genirack.nyu.edu:12369/protogeni/xmlrpc/am/1.0
 nyu-ig2=urn:publicid:IDN+genirack.nyu.edu+authority+cm,https://genirack.nyu.edu:12369/protogeni/xmlrpc/am/2.0
 nyu-ig3=urn:publicid:IDN+genirack.nyu.edu+authority+cm,https://genirack.nyu.edu:12369/protogeni/xmlrpc/am/3.0
-nyu-ig-of=urn:publicid:IDN+openflow:foam:foam.genirack.nyu.edu+authority+am,https://foam.genirack.nyu.edu:3626/foam/gapi/2
-nyu-ig-of1=urn:publicid:IDN+openflow:foam:foam.genirack.nyu.edu+authority+am,https://foam.genirack.nyu.edu:3626/foam/gapi/1
-nyu-ig-of2=urn:publicid:IDN+openflow:foam:foam.genirack.nyu.edu+authority+am,https://foam.genirack.nyu.edu:3626/foam/gapi/2
 
 # ============================================
 # Illinois InstaGENI Rack
@@ -287,9 +244,6 @@ illinois-ig=urn:publicid:IDN+instageni.illinois.edu+authority+cm,https://instage
 illinois-ig1=urn:publicid:IDN+instageni.illinois.edu+authority+cm,https://instageni.illinois.edu:12369/protogeni/xmlrpc/am/1.0
 illinois-ig2=urn:publicid:IDN+instageni.illinois.edu+authority+cm,https://instageni.illinois.edu:12369/protogeni/xmlrpc/am/2.0
 illinois-ig3=urn:publicid:IDN+instageni.illinois.edu+authority+cm,https://instageni.illinois.edu:12369/protogeni/xmlrpc/am/3.0
-illinois-ig-of=urn:publicid:IDN+openflow:foam:foam.instageni.illinois.edu+authority+am,https://foam.instageni.illinois.edu:3626/foam/gapi/2
-illinois-ig-of1=urn:publicid:IDN+openflow:foam:foam.instageni.illinois.edu+authority+am,https://foam.instageni.illinois.edu:3626/foam/gapi/1
-illinois-ig-of2=urn:publicid:IDN+openflow:foam:foam.instageni.illinois.edu+authority+am,https://foam.instageni.illinois.edu:3626/foam/gapi/2
 
 # ============================================
 # Wisconsin InstaGENI Rack
@@ -298,14 +252,6 @@ wisconsin-ig=urn:publicid:IDN+instageni.wisc.edu+authority+cm,https://instageni.
 wisconsin-ig1=urn:publicid:IDN+instageni.wisc.edu+authority+cm,https://instageni.wisc.edu:12369/protogeni/xmlrpc/am/1.0
 wisconsin-ig2=urn:publicid:IDN+instageni.wisc.edu+authority+cm,https://instageni.wisc.edu:12369/protogeni/xmlrpc/am/2.0
 wisconsin-ig3=urn:publicid:IDN+instageni.wisc.edu+authority+cm,https://instageni.wisc.edu:12369/protogeni/xmlrpc/am/3.0
-wisconsin-ig-of=urn:publicid:IDN+openflow:foam:foam.instageni.wisc.edu+authority+am,https://foam.instageni.wisc.edu:3626/foam/gapi/2
-wisconsin-ig-of1=urn:publicid:IDN+openflow:foam:foam.instageni.wisc.edu+authority+am,https://foam.instageni.wisc.edu:3626/foam/gapi/1
-wisconsin-ig-of2=urn:publicid:IDN+openflow:foam:foam.instageni.wisc.edu+authority+am,https://foam.instageni.wisc.edu:3626/foam/gapi/2
-
-# ============================================
-# Internet2 ION Aggregate for stitching - obsolete and decomissioned as of May, 2015
-# ============================================
-#ion=urn:publicid:IDN+ion.internet2.edu+authority+am,https://geni-am.net.internet2.edu:12346
 
 # ============================================
 # Cornell InstaGENI Rack
@@ -314,9 +260,6 @@ cornell-ig=urn:publicid:IDN+geni.it.cornell.edu+authority+cm,https://geni.it.cor
 cornell-ig1=urn:publicid:IDN+geni.it.cornell.edu+authority+cm,https://geni.it.cornell.edu:12369/protogeni/xmlrpc/am/1.0
 cornell-ig2=urn:publicid:IDN+geni.it.cornell.edu+authority+cm,https://geni.it.cornell.edu:12369/protogeni/xmlrpc/am/2.0
 cornell-ig3=urn:publicid:IDN+geni.it.cornell.edu+authority+cm,https://geni.it.cornell.edu:12369/protogeni/xmlrpc/am/3.0
-cornell-ig-of=urn:publicid:IDN+openflow:foam:foam.geni.it.cornell.edu+authority+am,https://foam.geni.it.cornell.edu:3626/foam/gapi/2
-cornell-ig-of1=urn:publicid:IDN+openflow:foam:foam.geni.it.cornell.edu+authority+am,https://foam.geni.it.cornell.edu:3626/foam/gapi/1
-cornell-ig-of2=urn:publicid:IDN+openflow:foam:foam.geni.it.cornell.edu+authority+am,https://foam.geni.it.cornell.edu:3626/foam/gapi/2
 
 # ============================================
 # Southern Crossroads (SoX) InstaGENI Rack
@@ -325,9 +268,6 @@ sox-ig=urn:publicid:IDN+instageni.sox.net+authority+cm,https://instageni.sox.net
 sox-ig1=urn:publicid:IDN+instageni.sox.net+authority+cm,https://instageni.sox.net:12369/protogeni/xmlrpc/am/1.0
 sox-ig2=urn:publicid:IDN+instageni.sox.net+authority+cm,https://instageni.sox.net:12369/protogeni/xmlrpc/am/2.0
 sox-ig3=urn:publicid:IDN+instageni.sox.net+authority+cm,https://instageni.sox.net:12369/protogeni/xmlrpc/am/3.0
-sox-ig-of=urn:publicid:IDN+openflow:foam:foam.instageni.sox.net+authority+am,https://foam.instageni.sox.net:3626/foam/gapi/2
-sox-ig-of1=urn:publicid:IDN+openflow:foam:foam.instageni.sox.net+authority+am,https://foam.instageni.sox.net:3626/foam/gapi/1
-sox-ig-of2=urn:publicid:IDN+openflow:foam:foam.instageni.sox.net+authority+am,https://foam.instageni.sox.net:3626/foam/gapi/2
 
 # ============================================
 # University of Kansas InstaGENI Rack
@@ -336,9 +276,6 @@ kansas-ig=urn:publicid:IDN+instageni.ku.gpeni.net+authority+cm,https://instageni
 kansas-ig1=urn:publicid:IDN+instageni.ku.gpeni.net+authority+cm,https://instageni.ku.gpeni.net:12369/protogeni/xmlrpc/am/1.0
 kansas-ig2=urn:publicid:IDN+instageni.ku.gpeni.net+authority+cm,https://instageni.ku.gpeni.net:12369/protogeni/xmlrpc/am/2.0
 kansas-ig3=urn:publicid:IDN+instageni.ku.gpeni.net+authority+cm,https://instageni.ku.gpeni.net:12369/protogeni/xmlrpc/am/3.0
-kansas-ig-of=urn:publicid:IDN+openflow:foam:foam.instageni.ku.gpeni.net+authority+am,https://foam.instageni.ku.gpeni.net:3626/foam/gapi/2
-kansas-ig-of1=urn:publicid:IDN+openflow:foam:foam.instageni.ku.gpeni.net+authority+am,https://foam.instageni.ku.gpeni.net:3626/foam/gapi/1
-kansas-ig-of2=urn:publicid:IDN+openflow:foam:foam.instageni.ku.gpeni.net+authority+am,https://foam.instageni.ku.gpeni.net:3626/foam/gapi/2
 
 # ============================================
 # Stanford University InstaGENI Rack
@@ -347,9 +284,6 @@ stanford-ig=urn:publicid:IDN+instageni.stanford.edu+authority+cm,https://instage
 stanford-ig1=urn:publicid:IDN+instageni.stanford.edu+authority+cm,https://instageni.stanford.edu:12369/protogeni/xmlrpc/am/1.0
 stanford-ig2=urn:publicid:IDN+instageni.stanford.edu+authority+cm,https://instageni.stanford.edu:12369/protogeni/xmlrpc/am/2.0
 stanford-ig3=urn:publicid:IDN+instageni.stanford.edu+authority+cm,https://instageni.stanford.edu:12369/protogeni/xmlrpc/am/3.0
-stanford-ig-of=urn:publicid:IDN+openflow:foam:foam.instageni.stanford.edu+authority+am,https://foam.instageni.stanford.edu:3626/foam/gapi/2
-stanford-ig-of1=urn:publicid:IDN+openflow:foam:foam.instageni.stanford.edu+authority+am,https://foam.instageni.stanford.edu:3626/foam/gapi/1
-stanford-ig-of2=urn:publicid:IDN+openflow:foam:foam.instageni.stanford.edu+authority+am,https://foam.instageni.stanford.edu:3626/foam/gapi/2
 
 # ============================================
 # Starlight OpenFlow
@@ -398,9 +332,6 @@ cenic-ig=urn:publicid:IDN+instageni.cenic.net+authority+cm,https://instageni.cen
 cenic-ig1=urn:publicid:IDN+instageni.cenic.net+authority+cm,https://instageni.cenic.net:12369/protogeni/xmlrpc/am/1.0
 cenic-ig2=urn:publicid:IDN+instageni.cenic.net+authority+cm,https://instageni.cenic.net:12369/protogeni/xmlrpc/am/2.0
 cenic-ig3=urn:publicid:IDN+instageni.cenic.net+authority+cm,https://instageni.cenic.net:12369/protogeni/xmlrpc/am/3.0
-cenic-ig-of=urn:publicid:IDN+openflow:foam:foam.instageni.cenic.net+authority+am,https://foam.instageni.cenic.net:3626/foam/gapi/2
-cenic-ig-of1=urn:publicid:IDN+openflow:foam:foam.instageni.cenic.net+authority+am,https://foam.instageni.cenic.net:3626/foam/gapi/1
-cenic-ig-of2=urn:publicid:IDN+openflow:foam:foam.instageni.cenic.net+authority+am,https://foam.instageni.cenic.net:3626/foam/gapi/2
 
 # ======
 # Ohio Metro Data Center InstaGENI
@@ -409,9 +340,6 @@ ohmetrodc-ig=urn:publicid:IDN+instageni.metrodatacenter.com+authority+cm,https:/
 ohmetrodc-ig1=urn:publicid:IDN+instageni.metrodatacenter.com+authority+cm,https://instageni.metrodatacenter.com:12369/protogeni/xmlrpc/am/1.0
 ohmetrodc-ig2=urn:publicid:IDN+instageni.metrodatacenter.com+authority+cm,https://instageni.metrodatacenter.com:12369/protogeni/xmlrpc/am/2.0
 ohmetrodc-ig3=urn:publicid:IDN+instageni.metrodatacenter.com+authority+cm,https://instageni.metrodatacenter.com:12369/protogeni/xmlrpc/am/3.0
-ohmetrodc-ig-of=urn:publicid:IDN+openflow:foam:foam.instageni.metrodatacenter.com+authority+am,https://foam.instageni.metrodatacenter.com:3626/foam/gapi/2
-ohmetrodc-ig-of1=urn:publicid:IDN+openflow:foam:foam.instageni.metrodatacenter.com+authority+am,https://foam.instageni.metrodatacenter.com:3626/foam/gapi/1
-ohmetrodc-ig-of2=urn:publicid:IDN+openflow:foam:foam.instageni.metrodatacenter.com+authority+am,https://foam.instageni.metrodatacenter.com:3626/foam/gapi/2
 
 # ======
 # Naval Postgraduate School InstaGENI
@@ -420,9 +348,6 @@ nps-ig=urn:publicid:IDN+instageni.nps.edu+authority+cm,https://instageni.nps.edu
 nps-ig1=urn:publicid:IDN+instageni.nps.edu+authority+cm,https://instageni.nps.edu:12369/protogeni/xmlrpc/am/1.0
 nps-ig2=urn:publicid:IDN+instageni.nps.edu+authority+cm,https://instageni.nps.edu:12369/protogeni/xmlrpc/am/2.0
 nps-ig3=urn:publicid:IDN+instageni.nps.edu+authority+cm,https://instageni.nps.edu:12369/protogeni/xmlrpc/am/3.0
-nps-ig-of=urn:publicid:IDN+openflow:foam:foam.instageni.nps.edu+authority+am,https://foam.instageni.nps.edu:3626/foam/gapi/2
-nps-ig-of1=urn:publicid:IDN+openflow:foam:foam.instageni.nps.edu+authority+am,https://foam.instageni.nps.edu:3626/foam/gapi/1
-nps-ig-of2=urn:publicid:IDN+openflow:foam:foam.instageni.nps.edu+authority+am,https://foam.instageni.nps.edu:3626/foam/gapi/2
 
 # ======
 # Midwest OpenFlow Crossroads Initiative (MOXI) InstaGENI
@@ -431,9 +356,6 @@ moxi-ig=urn:publicid:IDN+instageni.iu.edu+authority+cm,https://instageni.iu.edu:
 moxi-ig1=urn:publicid:IDN+instageni.iu.edu+authority+cm,https://instageni.iu.edu:12369/protogeni/xmlrpc/am/1.0
 moxi-ig2=urn:publicid:IDN+instageni.iu.edu+authority+cm,https://instageni.iu.edu:12369/protogeni/xmlrpc/am/2.0
 moxi-ig3=urn:publicid:IDN+instageni.iu.edu+authority+cm,https://instageni.iu.edu:12369/protogeni/xmlrpc/am/3.0
-moxi-ig-of=urn:publicid:IDN+openflow:foam:foam.instageni.iu.edu+authority+am,https://foam.instageni.iu.edu:3626/foam/gapi/2
-moxi-ig-of1=urn:publicid:IDN+openflow:foam:foam.instageni.iu.edu+authority+am,https://foam.instageni.iu.edu:3626/foam/gapi/1
-moxi-ig-of2=urn:publicid:IDN+openflow:foam:foam.instageni.iu.edu+authority+am,https://foam.instageni.iu.edu:3626/foam/gapi/2
 
 # ======
 # Princeton InstaGENI
@@ -442,9 +364,6 @@ princeton-ig=urn:publicid:IDN+instageni.cs.princeton.edu+authority+cm,https://in
 princeton-ig1=urn:publicid:IDN+instageni.cs.princeton.edu+authority+cm,https://instageni.cs.princeton.edu:12369/protogeni/xmlrpc/am/1.0
 princeton-ig2=urn:publicid:IDN+instageni.cs.princeton.edu+authority+cm,https://instageni.cs.princeton.edu:12369/protogeni/xmlrpc/am/2.0
 princeton-ig3=urn:publicid:IDN+instageni.cs.princeton.edu+authority+cm,https://instageni.cs.princeton.edu:12369/protogeni/xmlrpc/am/3.0
-princeton-ig-of=urn:publicid:IDN+openflow:foam:foam.instageni.cs.princeton.edu+authority+am,https://foam.instageni.cs.princeton.edu:3626/foam/gapi/2
-princeton-ig-of1=urn:publicid:IDN+openflow:foam:foam.instageni.cs.princeton.edu+authority+am,https://foam.instageni.cs.princeton.edu:3626/foam/gapi/1
-princeton-ig-of2=urn:publicid:IDN+openflow:foam:foam.instageni.cs.princeton.edu+authority+am,https://foam.instageni.cs.princeton.edu:3626/foam/gapi/2
 
 # ======
 # Rutgers InstaGENI
@@ -453,9 +372,6 @@ rutgers-ig=urn:publicid:IDN+instageni.rutgers.edu+authority+cm,https://instageni
 rutgers-ig1=urn:publicid:IDN+instageni.rutgers.edu+authority+cm,https://instageni.rutgers.edu:12369/protogeni/xmlrpc/am/1.0
 rutgers-ig2=urn:publicid:IDN+instageni.rutgers.edu+authority+cm,https://instageni.rutgers.edu:12369/protogeni/xmlrpc/am/2.0
 rutgers-ig3=urn:publicid:IDN+instageni.rutgers.edu+authority+cm,https://instageni.rutgers.edu:12369/protogeni/xmlrpc/am/3.0
-rutgers-ig-of=urn:publicid:IDN+openflow:foam:foam.instageni.rutgers.edu+authority+am,https://foam.instageni.rutgers.edu:3626/foam/gapi/2
-rutgers-ig-of1=urn:publicid:IDN+openflow:foam:foam.instageni.rutgers.edu+authority+am,https://foam.instageni.rutgers.edu:3626/foam/gapi/1
-rutgers-ig-of2=urn:publicid:IDN+openflow:foam:foam.instageni.rutgers.edu+authority+am,https://foam.instageni.rutgers.edu:3626/foam/gapi/2
 
 # ======
 # U Kentucky Parking Structure (PKS2) InstaGENI
@@ -464,9 +380,6 @@ ukypks2-ig=urn:publicid:IDN+pks2.sdn.uky.edu+authority+cm,https://pks2.sdn.uky.e
 ukypks2-ig1=urn:publicid:IDN+pks2.sdn.uky.edu+authority+cm,https://pks2.sdn.uky.edu:12369/protogeni/xmlrpc/am/1.0
 ukypks2-ig2=urn:publicid:IDN+pks2.sdn.uky.edu+authority+cm,https://pks2.sdn.uky.edu:12369/protogeni/xmlrpc/am/2.0
 ukypks2-ig3=urn:publicid:IDN+pks2.sdn.uky.edu+authority+cm,https://pks2.sdn.uky.edu:12369/protogeni/xmlrpc/am/3.0
-ukypks2-ig-of=urn:publicid:IDN+openflow:foam:foam.pks2.sdn.uky.edu+authority+am,https://foam.pks2.sdn.uky.edu:3626/foam/gapi/2
-ukypks2-ig-of1=urn:publicid:IDN+openflow:foam:foam.pks2.sdn.uky.edu+authority+am,https://foam.pks2.sdn.uky.edu:3626/foam/gapi/1
-ukypks2-ig-of2=urn:publicid:IDN+openflow:foam:foam.pks2.sdn.uky.edu+authority+am,https://foam.pks2.sdn.uky.edu:3626/foam/gapi/2
 
 # ======
 # UCLA InstaGENI
@@ -475,9 +388,6 @@ ucla-ig=urn:publicid:IDN+instageni.idre.ucla.edu+authority+cm,https://instageni.
 ucla-ig1=urn:publicid:IDN+instageni.idre.ucla.edu+authority+cm,https://instageni.idre.ucla.edu:12369/protogeni/xmlrpc/am/1.0
 ucla-ig2=urn:publicid:IDN+instageni.idre.ucla.edu+authority+cm,https://instageni.idre.ucla.edu:12369/protogeni/xmlrpc/am/2.0
 ucla-ig3=urn:publicid:IDN+instageni.idre.ucla.edu+authority+cm,https://instageni.idre.ucla.edu:12369/protogeni/xmlrpc/am/3.0
-ucla-ig-of=urn:publicid:IDN+openflow:foam:foam.instageni.idre.ucla.edu+authority+am,https://foam.instageni.idre.ucla.edu:3626/foam/gapi/2
-ucla-ig-of1=urn:publicid:IDN+openflow:foam:foam.instageni.idre.ucla.edu+authority+am,https://foam.instageni.idre.ucla.edu:3626/foam/gapi/1
-ucla-ig-of2=urn:publicid:IDN+openflow:foam:foam.instageni.idre.ucla.edu+authority+am,https://foam.instageni.idre.ucla.edu:3626/foam/gapi/2
 
 # ======
 # Oakland Scientific Facility (OSF) ExoGENI
@@ -624,9 +534,6 @@ colorado-ig=urn:publicid:IDN+instageni.colorado.edu+authority+cm,https://instage
 colorado-ig1=urn:publicid:IDN+instageni.colorado.edu+authority+cm,https://instageni.colorado.edu:12369/protogeni/xmlrpc/am/1.0
 colorado-ig2=urn:publicid:IDN+instageni.colorado.edu+authority+cm,https://instageni.colorado.edu:12369/protogeni/xmlrpc/am/2.0
 colorado-ig3=urn:publicid:IDN+instageni.colorado.edu+authority+cm,https://instageni.colorado.edu:12369/protogeni/xmlrpc/am/3.0
-colorado-ig-of=urn:publicid:IDN+openflow:foam:foam.instageni.colorado.edu+authority+am,https://foam.instageni.colorado.edu:3626/foam/gapi/2
-colorado-ig-of1=urn:publicid:IDN+openflow:foam:foam.instageni.colorado.edu+authority+am,https://foam.instageni.colorado.edu:3626/foam/gapi/1
-colorado-ig-of2=urn:publicid:IDN+openflow:foam:foam.instageni.colorado.edu+authority+am,https://foam.instageni.colorado.edu:3626/foam/gapi/2
 
 # =====
 # Case Western Reserve University InstaGENI
@@ -643,9 +550,6 @@ umkc-ig=urn:publicid:IDN+instageni.umkc.edu+authority+cm,https://instageni.umkc.
 umkc-ig1=urn:publicid:IDN+instageni.umkc.edu+authority+cm,https://instageni.umkc.edu:12369/protogeni/xmlrpc/am/1.0
 umkc-ig2=urn:publicid:IDN+instageni.umkc.edu+authority+cm,https://instageni.umkc.edu:12369/protogeni/xmlrpc/am/2.0
 umkc-ig3=urn:publicid:IDN+instageni.umkc.edu+authority+cm,https://instageni.umkc.edu:12369/protogeni/xmlrpc/am/3.0
-umkc-ig-of=urn:publicid:IDN+openflow:foam:foam.instageni.umkc.edu+authority+am,https://foam.instageni.umkc.edu:3626/foam/gapi/2
-umkc-ig-of1=urn:publicid:IDN+openflow:foam:foam.instageni.umkc.edu+authority+am,https://foam.instageni.umkc.edu:3626/foam/gapi/1
-umkc-ig-of2=urn:publicid:IDN+openflow:foam:foam.instageni.umkc.edu+authority+am,https://foam.instageni.umkc.edu:3626/foam/gapi/2
 
 # =====
 # University of Tennessee at Chattanooga InstaGENI
@@ -654,9 +558,6 @@ utc-ig=urn:publicid:IDN+instageni.utc.edu+authority+cm,https://instageni.utc.edu
 utc-ig1=urn:publicid:IDN+instageni.utc.edu+authority+cm,https://instageni.utc.edu:12369/protogeni/xmlrpc/am/1.0
 utc-ig2=urn:publicid:IDN+instageni.utc.edu+authority+cm,https://instageni.utc.edu:12369/protogeni/xmlrpc/am/2.0
 utc-ig3=urn:publicid:IDN+instageni.utc.edu+authority+cm,https://instageni.utc.edu:12369/protogeni/xmlrpc/am/3.0
-utc-ig-of=urn:publicid:IDN+openflow:foam:foam.instageni.utc.edu+authority+am,https://foam.instageni.utc.edu:3626/foam/gapi/2
-utc-ig-of1=urn:publicid:IDN+openflow:foam:foam.instageni.utc.edu+authority+am,https://foam.instageni.utc.edu:3626/foam/gapi/1
-utc-ig-of2=urn:publicid:IDN+openflow:foam:foam.instageni.utc.edu+authority+am,https://foam.instageni.utc.edu:3626/foam/gapi/2
 
 # =====
 # University of Washington InstaGENI
@@ -665,9 +566,6 @@ uwashington-ig=urn:publicid:IDN+instageni.washington.edu+authority+cm,https://in
 uwashington-ig1=urn:publicid:IDN+instageni.washington.edu+authority+cm,https://instageni.washington.edu:12369/protogeni/xmlrpc/am/1.0
 uwashington-ig2=urn:publicid:IDN+instageni.washington.edu+authority+cm,https://instageni.washington.edu:12369/protogeni/xmlrpc/am/2.0
 uwashington-ig3=urn:publicid:IDN+instageni.washington.edu+authority+cm,https://instageni.washington.edu:12369/protogeni/xmlrpc/am/3.0
-uwashington-ig-of=urn:publicid:IDN+openflow:foam:foam.instageni.washington.edu+authority+am,https://foam.instageni.washington.edu:3626/foam/gapi/2
-uwashington-ig-of1=urn:publicid:IDN+openflow:foam:foam.instageni.washington.edu+authority+am,https://foam.instageni.washington.edu:3626/foam/gapi/1
-uwashington-ig-of2=urn:publicid:IDN+openflow:foam:foam.instageni.washington.edu+authority+am,https://foam.instageni.washington.edu:3626/foam/gapi/2
 
 # =====
 # University of Chicago InstaGENI
@@ -729,9 +627,6 @@ umich-ig=urn:publicid:IDN+instageni.research.umich.edu+authority+cm,https://inst
 umich-ig1=urn:publicid:IDN+instageni.research.umich.edu+authority+cm,https://instageni.research.umich.edu:12369/protogeni/xmlrpc/am/1.0
 umich-ig2=urn:publicid:IDN+instageni.research.umich.edu+authority+cm,https://instageni.research.umich.edu:12369/protogeni/xmlrpc/am/2.0
 umich-ig3=urn:publicid:IDN+instageni.research.umich.edu+authority+cm,https://instageni.research.umich.edu:12369/protogeni/xmlrpc/am/3.0
-umich-ig-of=urn:publicid:IDN+openflow:foam:foam.instageni.research.umich.edu+authority+am,https://foam.instageni.research.umich.edu:3626/foam/gapi/2
-umich-ig-of1=urn:publicid:IDN+openflow:foam:foam.instageni.research.umich.edu+authority+am,https://foam.instageni.research.umich.edu:3626/foam/gapi/1
-umich-ig-of2=urn:publicid:IDN+openflow:foam:foam.instageni.research.umich.edu+authority+am,https://foam.instageni.research.umich.edu:3626/foam/gapi/2
 
 # =====
 # University of Kentucky MCV InstaGENI
@@ -740,6 +635,3 @@ ukymcv-ig=urn:publicid:IDN+mcv.sdn.uky.edu+authority+cm,https://mcv.sdn.uky.edu:
 ukymcv-ig1=urn:publicid:IDN+mcv.sdn.uky.edu+authority+cm,https://mcv.sdn.uky.edu:12369/protogeni/xmlrpc/am/1.0
 ukymcv-ig2=urn:publicid:IDN+mcv.sdn.uky.edu+authority+cm,https://mcv.sdn.uky.edu:12369/protogeni/xmlrpc/am/2.0
 ukymcv-ig3=urn:publicid:IDN+mcv.sdn.uky.edu+authority+cm,https://mcv.sdn.uky.edu:12369/protogeni/xmlrpc/am/3.0
-ukymcv-ig-of=urn:publicid:IDN+openflow:foam:foam.mcv.sdn.uky.edu+authority+am,https://foam.mcv.sdn.uky.edu:3626/foam/gapi/2
-ukymcv-ig-of1=urn:publicid:IDN+openflow:foam:foam.mcv.sdn.uky.edu+authority+am,https://foam.mcv.sdn.uky.edu:3626/foam/gapi/1
-ukymcv-ig-of2=urn:publicid:IDN+openflow:foam:foam.mcv.sdn.uky.edu+authority+am,https://foam.mcv.sdn.uky.edu:3626/foam/gapi/2


### PR DESCRIPTION
InstaGENI FOAM aggregates are being decommissioned. Remove them from
the aggregate nickname list.