### PR TITLE
Add multi-thread support for AM3

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@
 gcf 2.11:
  * Remove bogus check for rspec tag (#885)
  * Properly remove prefix from signature refid in SFA credentials. (#890)
+ * Add multi-thread support for AM3 (#901)
 
 gcf 2.10:
  * Changed references to trac.gpolab.bbn.com to point to Github.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -25,5 +25,6 @@ Past contributors have included:
  - Tom Mitchell, Raytheon BBN Technologies
  - Aaron Helsinger, Raytheon BBN Technologies
  - Eduardo Miravalls Sierra, HPCN Lab of University UAM
+ - Arthur Garnier, Inria
 
 Thank you!

--- a/gcf_config.sample
+++ b/gcf_config.sample
@@ -68,6 +68,12 @@ name=am1
 # If a -D/--delegate option is supplied, that takes precedence
 # delegate=gcf.geni.am.am2.ReferenceAggregateManager
 
+# By default (false) the Aggregate API will accept only one connection at the same time
+# Set this to 'true' if you want to enable multi-threaded XMLRPC server
+# Be sure your (delegate) code is designed to handle multiple requests at the same time (concurrence)
+# This option only works for AM Version 3
+multithread=false
+
 # Address that the AM listens on
 host=127.0.0.1
 port=8001

--- a/src/gcf-am.py
+++ b/src/gcf-am.py
@@ -168,7 +168,7 @@ def main(argv=None):
             logging.getLogger('gcf-am').error(msg)
             sys.exit(msg)
 
-    multithread = None
+    multithread = False
     if hasattr(opts, 'multithread') and opts.multithread is not None and str(opts.multithread).strip() != "":
         if str(opts.multithread).strip().lower() == "true":
             multithread = True

--- a/src/gcf-am.py
+++ b/src/gcf-am.py
@@ -168,6 +168,16 @@ def main(argv=None):
             logging.getLogger('gcf-am').error(msg)
             sys.exit(msg)
 
+    multithread = None
+    if hasattr(opts, 'multithread') and opts.multithread is not None and str(opts.multithread).strip() != "":
+        if str(opts.multithread).strip().lower() == "true":
+            multithread = True
+        elif str(opts.multithread).strip().lower() == "false":
+            multithread = False
+        else:
+            multithread = False
+            logging.getLogger('gcf-am').warning("Invalid argument for 'multithread', set default : false")
+
     # here rootcadir is supposed to be a single file with multiple
     # certs possibly concatenated together
     comboCertsFile = geni.CredentialVerifier.getCAsFileFromDir(getAbsPath(opts.rootcadir))
@@ -200,7 +210,7 @@ def main(argv=None):
                                                      base_name=config['global']['base_name'],
                                                      authorizer=authorizer,
                                                      resource_manager=resource_manager,
-                                                     delegate=delegate)
+                                                     delegate=delegate, multithread=multithread)
     else:
         msg = "Unknown API version: %d. Valid choices are \"1\", \"2\", or \"3\""
         sys.exit(msg % (opts.api_version))

--- a/src/gcf/geni/am/am3.py
+++ b/src/gcf/geni/am/am3.py
@@ -1387,7 +1387,7 @@ class AggregateManagerServer(object):
                  trust_roots_dir=None,
                  ca_certs=None, base_name=None,
                  authorizer=None, resource_manager=None,
-                 delegate=None, multithread=None):
+                 delegate=None, multithread=False):
         # ca_certs arg here must be a file of concatenated certs
         if ca_certs is None:
             raise Exception('Missing CA Certs')

--- a/src/gcf/geni/am/am3.py
+++ b/src/gcf/geni/am/am3.py
@@ -54,6 +54,7 @@ from ..util.tz_util import tzd
 from ..util.urn_util import publicid_to_urn
 from ..util import urn_util as urn
 from ..SecureXMLRPCServer import SecureXMLRPCServer
+from ..SecureThreadedXMLRPCServer import SecureThreadedXMLRPCServer
 
 from ...sfa.trust.credential import Credential
 from ...sfa.trust.abac_credential import ABACCredential
@@ -1386,7 +1387,7 @@ class AggregateManagerServer(object):
                  trust_roots_dir=None,
                  ca_certs=None, base_name=None,
                  authorizer=None, resource_manager=None,
-                 delegate=None):
+                 delegate=None, multithread=None):
         # ca_certs arg here must be a file of concatenated certs
         if ca_certs is None:
             raise Exception('Missing CA Certs')
@@ -1401,7 +1402,12 @@ class AggregateManagerServer(object):
 
         # FIXED: set logRequests=true if --debug
         logRequest=logging.getLogger().getEffectiveLevel()==logging.DEBUG
-        self._server = SecureXMLRPCServer(addr, keyfile=keyfile,
+        if multithread:
+            self._server = SecureThreadedXMLRPCServer(addr, keyfile=keyfile,
+                                          certfile=certfile, ca_certs=ca_certs, 
+                                          logRequests=logRequest)
+        else:
+            self._server = SecureXMLRPCServer(addr, keyfile=keyfile,
                                           certfile=certfile, ca_certs=ca_certs, 
                                           logRequests=logRequest)
         aggregate_manager = AggregateManager(trust_roots_dir, delegate, 


### PR DESCRIPTION
When lots of request are done on the server some connections are closed due to the single thread. 
This option allows multi-thread XMLRPC server