### PR TITLE
Addresses #902: Added unf-eg to agg_nick_cache.base.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@
 gcf 2.11:
  * Remove bogus check for rspec tag (#885)
  * Properly remove prefix from signature refid in SFA credentials. (#890)
+ * Added unf-eg to agg_nick_cache.base. (#902)
 
 gcf 2.10:
  * Changed references to trac.gpolab.bbn.com to point to Github.

--- a/agg_nick_cache.base
+++ b/agg_nick_cache.base
@@ -635,3 +635,13 @@ ukymcv-ig=urn:publicid:IDN+mcv.sdn.uky.edu+authority+cm,https://mcv.sdn.uky.edu:
 ukymcv-ig1=urn:publicid:IDN+mcv.sdn.uky.edu+authority+cm,https://mcv.sdn.uky.edu:12369/protogeni/xmlrpc/am/1.0
 ukymcv-ig2=urn:publicid:IDN+mcv.sdn.uky.edu+authority+cm,https://mcv.sdn.uky.edu:12369/protogeni/xmlrpc/am/2.0
 ukymcv-ig3=urn:publicid:IDN+mcv.sdn.uky.edu+authority+cm,https://mcv.sdn.uky.edu:12369/protogeni/xmlrpc/am/3.0
+
+
+# New Aggregate August, 2016
+
+# ======
+# UNF ExoGENI
+# ======
+unf-eg=urn:publicid:IDN+exogeni.net:unfvmsite+authority+am,https://unf-hn.exogeni.net:11443/orca/xmlrpc
+unf-eg2=urn:publicid:IDN+exogeni.net:unfvmsite+authority+am,https://unf-hn.exogeni.net:11443/orca/xmlrpc
+


### PR DESCRIPTION
It appears that "unf-eg" exists in omni "nicknames.txt", but running "getversion" resulted in the following error:
{{{
$ omni -a unf-eg getversion --NoAggNickCache

Downloaded latest `agg_nick_cache` from 'https://raw.githubusercontent.com/GENI-NSF/geni-tools/master/agg_nick_cache.base' and copied to '/home/asydney/.gcf/agg_nick_cache'.
...
Failed to find an AM nickname 'unf-eg'.  If you think this is an error, try using --NoAggNickCache to force the AM nickname cache to update.
}}}

Hence, I've added unf-eg to agg_nick_cache.base.
