### PR TITLE
ReferenceAggregateManager

### DIFF
--- a/src/gcf/geni/am/am2.py
+++ b/src/gcf/geni/am/am2.py
@@ -132,7 +132,7 @@ class ReferenceAggregateManager(object):
         self._agg.add_resources([FakeVM(self._agg) for _ in range(3)])
         self._cred_verifier = geni.CredentialVerifier(root_cert)
         self._urn_authority = urn_authority
-        self._my_urn = publicid_to_urn("%s %s %s" % (self._urn_authority, 'authority', 'am'))
+        self._my_urn = publicid_to_urn("IDN %s %s %s" % (self._urn_authority, 'authority', 'am'))
         self.max_lease = datetime.timedelta(days=REFAM_MAXLEASE_DAYS)
         self.logger = logging.getLogger('gcf.am2')
         self.logger.info("Running %s AM v%d code version %s", self._am_type, self._api_version, GCF_VERSION)

--- a/src/gcf/geni/am/am3.py
+++ b/src/gcf/geni/am/am3.py
@@ -287,7 +287,7 @@ class ReferenceAggregateManager(object):
         self._slices = dict()
         self._agg = Aggregate()
         self._agg.add_resources([FakeVM(self._agg) for _ in range(20)])
-        self._my_urn = publicid_to_urn("%s %s %s" % (self._urn_authority, 'authority', 'am'))
+        self._my_urn = publicid_to_urn("IDN %s %s %s" % (self._urn_authority, 'authority', 'am'))
         self.max_lease = datetime.timedelta(minutes=REFAM_MAXLEASE_MINUTES)
         self.max_alloc = datetime.timedelta(seconds=ALLOCATE_EXPIRATION_SECONDS)
         self.logger = logging.getLogger('gcf.am3')


### PR DESCRIPTION
The ReferenceAggregateManager was presenting an illegal URN:
"urn:publicid:geni:gpo:gcf+authority+am"
instead of
"urn:publicid:IDN+geni:gpo:gcf+authority+am"
This was due to the lack of the "IDN" parameter on the **publicid_to_urn** method call.