### PR TITLE
Change EXPIRED to SLICE_EXPIRED or PROJECT_EXPIRED

### DIFF
--- a/README-omni.txt
+++ b/README-omni.txt
@@ -1209,7 +1209,8 @@ project. Supply `--debug` or `--devmode` to see a listing of your
 expired projects as well.
 
 Return object is a list of structs, containing
-`PROJECT_URN`, `PROJECT_UID`, `EXPIRED`, and `PROJECT_ROLE`. `EXPIRED` is a boolean.
+`PROJECT_URN`, `PROJECT_UID`, `PROJECT_EXPIRED`, and `PROJECT_ROLE`.
+`PROJECT_EXPIRED` is a boolean.
 
 Output directing options:
  * `-o` Save result in a file

--- a/README-omni.txt
+++ b/README-omni.txt
@@ -13,13 +13,13 @@ Managers (AMs) via the GENI AM API (the common API that GENI
 aggregates support).  The Omni client also communicates with
 clearinghouses and slice authorities (sometimes referred to as control
 frameworks) in order to create slices, delete slices, and
-enumerate available GENI Aggregate Managers (AMs). 
-A Control Framework (CF) is a framework of resources that provides 
-users with GENI accounts (credentials) that they can use to 
+enumerate available GENI Aggregate Managers (AMs).
+A Control Framework (CF) is a framework of resources that provides
+users with GENI accounts (credentials) that they can use to
 reserve resources in GENI AMs.
 
-See INSTALL.txt or 
-[https://github.com/GENI-NSF/geni-tools/wiki/QuickStart the Installation instructions] 
+See INSTALL.txt or
+[https://github.com/GENI-NSF/geni-tools/wiki/QuickStart the Installation instructions]
 for details on installing Omni.
 
 See README-omniconfigure.txt or
@@ -52,7 +52,7 @@ New in v2.10:
    (`HIGH:MEDIUM:!ADH:!SSLv2:!MD5:!RC4:@STRENGTH`) when using python2.7.
    This avoids some security issues, and allows Omni on older clients
    to connect to some updated servers. (#745)
- * Use `False` instead of `'f'` for `SLICE_EXPIRED` and `PROJECT_EXPIRED` when 
+ * Use `False` instead of `'f'` for `SLICE_EXPIRED` and `PROJECT_EXPIRED` when
    using Common Federation API clearinghouses. (#856)
   * Thanks to Umar Toseef for the bug report.
  * Do not assume `PROJECT_MEMBER_UID` is returned when listing project members,
@@ -114,9 +114,9 @@ New in v2.7:
    to try to sync up the CH records of slivers with truth
    as reported by the AM. (#634)
  * Make `useSliceMembers` True by default and deprecate the option. (#667)
-  * By default, Omni will create accounts and install SSH keys for members of your slice, 
-    if you are using a CHAPI style framework / Clearinghouse 
-    which allows defining slice members (as the GENI Clearinghouse does). 
+  * By default, Omni will create accounts and install SSH keys for members of your slice,
+    if you are using a CHAPI style framework / Clearinghouse
+    which allows defining slice members (as the GENI Clearinghouse does).
   * This is not a change for Omni users who configured Omni using the `omni-configure` script,
     which already forced that setting to true.
   * The old `--useSliceMembers` option is deprecated and will be
@@ -127,7 +127,7 @@ New in v2.7:
     your `omni_config` to over-ride the `useSliceMembers` default of True.
  * Honor the `useslicemembers` and `ignoreconfigusers` options in the `omni_config` (#671)
  * Fix `get_member_email` e.g. from `listprojectmembers` for speaks-for. (#676)
- * Fix nickname cache updating when temp and home directories are on 
+ * Fix nickname cache updating when temp and home directories are on
    different disks - use `shutil.move`. (#646)
  * Look for fallback `agg_nick_cache` in correct location (#662)
  * Use relative imports in `speaksfor_util` if possible. (#657)
@@ -135,17 +135,17 @@ New in v2.7:
  * Increase the sleep between busy SSL call retries from 15 to 20 seconds. (#697)
  * Rename `addAliases.sh` to `addAliases.command` for Mac install. (#647)
  * Add new section `omni_defaults` to the Omni config file. (#713)
-  * This should set system defaults. Where these overlap in meaning with other 
+  * This should set system defaults. Where these overlap in meaning with other
     omni_config or commandline options, let those take precedence.
   * Allow these `omni_defaults` to be specified in the `agg_nick_cache`. These
     are read before those in the per-user omni config. If a default is set
-    in the `agg_nick_cache`, that takes precedence over any value in 
-    the user's `omni_config`: if a user should be able to over-ride the 
+    in the `agg_nick_cache`, that takes precedence over any value in
+    the user's `omni_config`: if a user should be able to over-ride the
     default, use a different omni config setting (not in `omni_defaults`), or
     use a command line option.
-  * Stitcher uses this for the SCS URL. 
- * Allow FOAM/AL2S AMs to submit sliver URNs that are the slice URN with an ID 
-   appended. 
+  * Stitcher uses this for the SCS URL.
+ * Allow FOAM/AL2S AMs to submit sliver URNs that are the slice URN with an ID
+   appended.
   * This works around known bug http://groups.geni.net/geni/ticket/1294. (#719)
  * Work around malformed ION sliver URNs: (#722)
   * Allow submitting URNs that use the slice authority as the sliver authority.
@@ -156,7 +156,7 @@ New in v2.7:
  * Quiet down some debug logs when printing SSH keys and when talking to CHAPI. (#727)
 
 New in v2.6:
- * New function `removeslicemember <slice> <username>`: 
+ * New function `removeslicemember <slice> <username>`:
    Remove the user with the given username from the named slice. (#515)
  * Add functions `listprojects` to list your projects, and `listprojectmembers`
    to list the members of a project and their role in the project and
@@ -240,7 +240,7 @@ Highlights:
 
 
 Details:
- - Add a new framework type `chapi` for talking the Uniform Federation API 
+ - Add a new framework type `chapi` for talking the Uniform Federation API
    (http://groups.geni.net/geni/wiki/UniformClearinghouseAPI)
    to compliant clearinghouses (e.g. GENI Clearinghouse). (#345, #440)
   - See `omni_config.sample` for config options required
@@ -256,7 +256,7 @@ sa=https://ch.geni.net/SA
   - When creating or renewing or deleting slivers, tell the Slice Authority.
     This allows the SA to know (non-authoritatively) where your slice
     has resources. (#439)
-  - New function `listslivers <slice>`: lists the slivers reported to 
+  - New function `listslivers <slice>`: lists the slivers reported to
     the slice authority in the given slice, by aggregate (with
     the sliver expirations). Note that this information is not
     authoritative - contact the aggregates if you want to be sure
@@ -275,7 +275,7 @@ sa=https://ch.geni.net/SA
  - When using the new `chapi` framework allow a `--useSliceAggregates`
    option to specify that the aggregate action should be taken at all
    aggregates at which you have resources in this slice. (#507)
-  - Any `-a` aggregates are extra. 
+  - Any `-a` aggregates are extra.
   - At other frameworks, this is ignored.
   - This option is ignored for commands like `createsliver`,
   `allocate`, `provision`, and `getversion`.
@@ -287,7 +287,7 @@ sa=https://ch.geni.net/SA
    compute resources. Default behavior is unchanged. These options
    control what users are created and SSH keys installed in new
    slivers from `createsliver` or `provision`, or when you update
-   the installed users and keys using 
+   the installed users and keys using
    `performoperationalaction <slice> geni_update_users`.
    If you supply the new option `--useSliceMembers` and your
    clearinghouse supports listing slice members (i.e. the new `chapi`
@@ -305,7 +305,7 @@ sa=https://ch.geni.net/SA
    users and keys that is supplied with `performoperationalaction`.
    However, if you do not supply the `geni_users` option from a file,
    Omni uses the same logic as for `createsliver`, optionally
-   querying your clearinghouse for slice members, and by default 
+   querying your clearinghouse for slice members, and by default
    reading users and keys configured in your `omni_config`. (#491)
  - If set, `GENI_FRAMEWORK` environment variable is the default for
    the `--framework` option (#315)
@@ -338,7 +338,7 @@ sa=https://ch.geni.net/SA
    - Change `import omni` to `import gcf.oscript as omni`
  - Avoid sending options to `getversion` if there are none, to support querying v1 AMs (#375)
  - Fix passing speaksfor and other options to `createsliver`, `renewsliver` (#377)
- - `renewslice` when given a slice credential replaces the saved 
+ - `renewslice` when given a slice credential replaces the saved
    slice credential in place, rather than in a new filename. (#386)
  - Create any directories needed in the path to the agg_nick_cache (#383)
  - If using `--AggNickCacheName` and can't read/write to the specified
@@ -385,7 +385,7 @@ sa=https://ch.geni.net/SA
    `listimages`. (#532)
  - Allow underscore in generated clean filenames (#533)
  - Handle `createslice` errors at the GENI Clearinghouse that might
-   be due to having the wrong case, now the project and slice names 
+   be due to having the wrong case, now the project and slice names
    are case sensitive. (#535)
  - Trim trailing newlines before installing SSH keys (#537)
  - Explicitly import framework files in `oscript.py` to support
@@ -430,9 +430,9 @@ configuration has been done. (You will see an error like:
 '`No handlers could be found for logger "omni"`'.)
 
 For further control of Omni output, use Omni as a library from your
-own python script (see [#OmniasaLibrary below] for details). 
+own python script (see [#OmniasaLibrary below] for details).
 For example, your script can modify the `-l` logging config file
-option between Omni calls. 
+option between Omni calls.
 Alternatively, you can call the Omni function
 `omni.applyLogConfig(<path to your log config file>)`. See the
 documentation for `applyLogConfig` for details.
@@ -449,18 +449,18 @@ count).
 
 Omni is really a thin wrapper around `src/gcf/oscript.py`, which can
 be imported as a library, enabling programmatic
-access to Omni functions. To use Omni as a library, 
+access to Omni functions. To use Omni as a library,
 `import gcf.oscript as omni` and use the `omni.call` function.
 
 Note that prior to v2.5, the import statement was `import omni` - be
 sure you have updated your scripts when you upgrade.
 
 {{{
-  text, returnStruct = omni.call( ['listmyslices', username], options )  
+  text, returnStruct = omni.call( ['listmyslices', username], options )
 }}}
 
-The return from `omni.call` is a list of 2 items: a human readable string summarizing the result 
-(possibly an error message), and the result object (may be `None` on error). The result 
+The return from `omni.call` is a list of 2 items: a human readable string summarizing the result
+(possibly an error message), and the result object (may be `None` on error). The result
 object type varies by the underlying command called. See the docs in
 the source code for individual methods.
 
@@ -472,9 +472,9 @@ Omni scripting allows a script to:
  * Control or suppress the logging in Omni (see the above section for details)
 
 For examples, see `src/stitcher.py` or `examples/expirationofmyslices.py` and `examples/myscript.py` in the gcf distribution.
-Or [https://github.com/GENI-NSF/geni-tools/wiki/Omni-Scripting-Example-Showing-Expiration Omni Scripting Expiration] 
+Or [https://github.com/GENI-NSF/geni-tools/wiki/Omni-Scripting-Example-Showing-Expiration Omni Scripting Expiration]
 and
-[https://github.com/GENI-NSF/geni-tools/wiki/Omni-Scripting-Example-With-Options Omni Scripting with Options] 
+[https://github.com/GENI-NSF/geni-tools/wiki/Omni-Scripting-Example-With-Options Omni Scripting with Options]
 on the gcf wiki.
 
 '''NOTE''': Omni uses multiple command line options, and creates its
@@ -487,15 +487,15 @@ Extending Omni to support additional frameworks with their own
 clearinghouse APIs requires adding a new Framework extension
 class. Adding other experiment management or utility functions can be
 done using Omni scripting, or by adding functions to
-`src/gcf/omnilib/amhandler.py`. 
+`src/gcf/omnilib/amhandler.py`.
 
 == Omni workflow ==
-For a fully worked simple example of using Omni, see 
+For a fully worked simple example of using Omni, see
 http://groups.geni.net/geni/wiki/HowToUseOmni
 
  1. Get your user certificate and keys: Pick a Clearinghouse you want to
     use (that is the control framework you will use). Get a user
-    certificate and key pair. 
+    certificate and key pair.
  2. Configure Omni: Be sure the appropriate section of omni_config for
     your framework (sfa/gcf/pg/chapi/pgch) has appropriate settings for
     contacting that CF, and user credentials that are valid for that
@@ -505,21 +505,21 @@ http://groups.geni.net/geni/wiki/HowToUseOmni
  3. Find available resources: Run `omni.py -o listresources`
   a. When you do this, Omni will contact your designated
      Clearinghouse, using your framework-specific user credentials.
-  b. The Clearinghouse will list the AMs it knows about. 
+  b. The Clearinghouse will list the AMs it knows about.
   c. Omni will then contact each of the AMs that the
      Clearinghouse told it about, and use the GENI AM API to ask each
-     for its resources. 
+     for its resources.
   d. Omni will save the Advertisement RSpec from each aggregate into a separate
      file (the `-o` option requested that). Files will be named
      `rspec-<server>.xml` or `rspec-<server>.json` depending on the AM
     API version you are using.
  4. Describe the resources you want to request: Create a request Rspec
     to specify which resources you want to reserve. (See
-    [http://groups.geni.net/geni/wiki/GENIExperimenter/RSpecs RSpec Documentation] 
+    [http://groups.geni.net/geni/wiki/GENIExperimenter/RSpecs RSpec Documentation]
     for more details.)
- 5. Create a Slice: 
+ 5. Create a Slice:
     Run: `omni.py createslice MySlice`
- 6. Allocate your resources: 
+ 6. Allocate your resources:
     Given a slice, and your request rspec file, you are ready to
     allocate resources by creating slivers at each of the AMs.   Note
     you must specify the URL or nickname of the aggregate where you
@@ -534,14 +534,14 @@ http://groups.geni.net/geni/wiki/HowToUseOmni
 
  In AM API v3 this requires 3 steps:
   Step 1:
-`omni.py -V 3 allocate -a myV3AM MySlice request.rspec` 
+`omni.py -V 3 allocate -a myV3AM MySlice request.rspec`
  Reserve the resources. Optionally you may delete the reservation if
  you didn't get what you wanted, or hold your reservation and try
  another reservation elsewhere to match. Be sure to `renew` your
  reservation if you want to hold it a while before you `provision` it.
 
   Step 2:
-`omni.py -V 3 provision -a myV3AM MySlice` 
+`omni.py -V 3 provision -a myV3AM MySlice`
  Start Instantiating the resources.
 
  At this point, you likely want to call `status` (see below), to check
@@ -563,12 +563,12 @@ http://groups.geni.net/geni/wiki/HowToUseOmni
  In AM API v1 & v2:
  When `geni_status` is `ready`, your resources are ready for your
  experiment to use.  Note: If `geni_status` is `unknown`, then
- your resources might be ready. 
+ your resources might be ready.
 
- In AM API v1 run: 
+ In AM API v1 run:
 `omni.py -V 1 sliverstatus -a pg-utah1 MySlice`
 
- In AM API v2 run: 
+ In AM API v2 run:
 `omni.py sliverstatus -a pg-utah MySlice`
 
  In AM API v3+:
@@ -587,23 +587,23 @@ http://groups.geni.net/geni/wiki/HowToUseOmni
  cases, the operational state will change from `geni_notready` to
  `geni_ready`.
 
- Run: 
+ Run:
 `omni.py -V 3 status -a myV3AM MySlice`
 
  8. Renew your slice and slivers: Both slices and slivers have
     distinct expiration times.  After a while you may want to Renew
     your Sliver before it expires and is deleted.
 
- AM API v1: 
+ AM API v1:
 `omni.py -V 1 renewsliver -a pg-utah1 MySlice 20120531`
 
  AM API v2:
 `omni.py renewsliver -a pg-utah MySlice 20120531`
- 
+
  AM API V3:
 `omni.py -V 3 renew -a myV3AM MySlice 20120531`
-    
- 9. Do your experiment! 
+
+ 9. Do your experiment!
 
  Compute resources typically use SSH to let you log in to the
  machines. The SSH keys configured in your omni_config `users` section
@@ -643,62 +643,62 @@ clearinghouse to be reminded of where you may have reservations, using `listsliv
 Omni supports the following command-line options.
 
 {{{
-$ ~/gcf/src/omni.py -h                            
-Usage: 
+$ ~/gcf/src/omni.py -h
+Usage:
 GENI Omni Command Line Aggregate Manager Tool Version 2.11
 Copyright (c) 2011-2016 Raytheon BBN Technologies
 
-omni.py [options] [--project <proj_name>] <command and arguments> 
+omni.py [options] [--project <proj_name>] <command and arguments>
 
- 	 Commands and their arguments are: 
- 		AM API functions: 
- 			 getversion 
- 			 listresources [In AM API V1 and V2 optional: slicename] 
- 			 describe slicename [AM API V3 only] 
- 			 createsliver <slicename> <rspec URL, filename, or nickname> [AM API V1&2 only] 
- 			 allocate <slicename> <rspec URL, filename, or nickname> [AM API V3 only] 
- 			 provision <slicename> [AM API V3 only] 
- 			 performoperationalaction <slicename> <action> [AM API V3 only] 
- 			 poa <slicename> <action> 
- 				 [alias for 'performoperationalaction'; AM API V3 only] 
+ 	 Commands and their arguments are:
+ 		AM API functions:
+ 			 getversion
+ 			 listresources [In AM API V1 and V2 optional: slicename]
+ 			 describe slicename [AM API V3 only]
+ 			 createsliver <slicename> <rspec URL, filename, or nickname> [AM API V1&2 only]
+ 			 allocate <slicename> <rspec URL, filename, or nickname> [AM API V3 only]
+ 			 provision <slicename> [AM API V3 only]
+ 			 performoperationalaction <slicename> <action> [AM API V3 only]
+ 			 poa <slicename> <action>
+ 				 [alias for 'performoperationalaction'; AM API V3 only]
  			 sliverstatus <slicename> [AMAPI V1&2 only]
  			 status <slicename> [AMAPI V3 only]
- 			 renewsliver <slicename> <new expiration time in UTC> [AM API V1&2 only] 
- 			 renew <slicename> <new expiration time in UTC> [AM API V3 only] 
- 			 deletesliver <slicename> [AM API V1&2 only] 
- 			 delete <slicename> [AM API V3 only] 
- 			 shutdown <slicename> 
- 			 update <slicename> <rspec URL, filename, or nickname> [Some AM API V3 AMs only] 
- 			 cancel <slicename> [Some AM API V3 AMs only] 
- 		Non AM API aggregate functions (supported by some aggregates): 
- 			 createimage <slicename> <imagename> [optional: false (keep image private)] -u <sliver urn> [ProtoGENI/InstaGENI only] 
- 			 snapshotimage <slicename> <imagename> [optional: false (keep image private)] -u <sliver urn> [ProtoGENI/InstaGENI only] 
- 				 [alias for 'createimage'] 
- 			 deleteimage <imageurn> [optional: creatorurn] [ProtoGENI/InstaGENI only] 
- 			 listimages [optional: creatorurn] [ProtoGENI/InstaGENI only] 
- 		Clearinghouse / Slice Authority functions: 
- 			 get_ch_version 
- 			 listaggregates 
- 			 createslice <slicename> 
- 			 getslicecred <slicename> 
- 			 renewslice <slicename> <new expiration time in UTC> 
- 			 deleteslice <slicename> 
+ 			 renewsliver <slicename> <new expiration time in UTC> [AM API V1&2 only]
+ 			 renew <slicename> <new expiration time in UTC> [AM API V3 only]
+ 			 deletesliver <slicename> [AM API V1&2 only]
+ 			 delete <slicename> [AM API V3 only]
+ 			 shutdown <slicename>
+ 			 update <slicename> <rspec URL, filename, or nickname> [Some AM API V3 AMs only]
+ 			 cancel <slicename> [Some AM API V3 AMs only]
+ 		Non AM API aggregate functions (supported by some aggregates):
+ 			 createimage <slicename> <imagename> [optional: false (keep image private)] -u <sliver urn> [ProtoGENI/InstaGENI only]
+ 			 snapshotimage <slicename> <imagename> [optional: false (keep image private)] -u <sliver urn> [ProtoGENI/InstaGENI only]
+ 				 [alias for 'createimage']
+ 			 deleteimage <imageurn> [optional: creatorurn] [ProtoGENI/InstaGENI only]
+ 			 listimages [optional: creatorurn] [ProtoGENI/InstaGENI only]
+ 		Clearinghouse / Slice Authority functions:
+ 			 get_ch_version
+ 			 listaggregates
+ 			 createslice <slicename>
+ 			 getslicecred <slicename>
+ 			 renewslice <slicename> <new expiration time in UTC>
+ 			 deleteslice <slicename>
  			 listslices [optional: username] [Alias for listmyslices]
- 			 listmyslices [optional: username] 
+ 			 listmyslices [optional: username]
  			 listprojects [optional: username] [Alias for listmyprojects]
- 			 listmyprojects [optional: username] 
+ 			 listmyprojects [optional: username]
  			 listmykeys [optional: username] [Alias for listkeys]
  			 listkeys [optional: username]
- 			 getusercred 
- 			 print_slice_expiration <slicename> 
- 			 listslivers <slicename> 
- 			 listprojectmembers <projectname> 
- 			 listslicemembers <slicename> 
- 			 addslicemember <slicename> <username> [optional: role] 
- 			 removeslicemember <slicename> <username>  
- 		Other functions: 
- 			 nicknames 
- 			 print_sliver_expirations <slicename> 
+ 			 getusercred
+ 			 print_slice_expiration <slicename>
+ 			 listslivers <slicename>
+ 			 listprojectmembers <projectname>
+ 			 listslicemembers <slicename>
+ 			 addslicemember <slicename> <username> [optional: role]
+ 			 removeslicemember <slicename> <username>
+ 		Other functions:
+ 			 nicknames
+ 			 print_sliver_expirations <slicename>
 
 	 See README-omni.txt for details.
 	 And see the Omni website at https://github.com/GENI-NSF/geni-tools/wiki
@@ -909,7 +909,7 @@ are relevant. Some notes on select options are provided here.
 
 Commonly used options:
 Omni provides many options. However, most users will only use a very
-few of them. 
+few of them.
  - `-a`: specify the aggregate at which to operate
  - `-r`: over-ride your default project setting
  - `--alap`: ask aggregates to renew your reservations as long as possible
@@ -1026,7 +1026,7 @@ Output directing options:
  * `--outputfile`: If supplied, use this output file name
  * If not saving results to a file, they are logged.
  * If intead of `-o` you specify the `--tostdout` option, then instead of logging, print to STDOUT.
- * File names will indicate the CH name from the omni config 
+ * File names will indicate the CH name from the omni config
   * e.g.: myprefix-portal-chversion.txt
 
 ==== listaggregates ====
@@ -1067,7 +1067,7 @@ your selected slice authority.
 
 Format:  `omni.py createslice <slice-name>`
 
-Sample Usage: 
+Sample Usage:
  * `omni.py createslice myslice`
  * Or to create the slice and save off the slice credential:
     `omni.py -o createslice myslice`
@@ -1284,7 +1284,7 @@ If you specify the `-o` option, the credential is saved to a file.
   If you specify the `--prefix` option then that string starts the filename.
 
 If instead of the `-o` option, you supply the `--tostdout` option, then
-the user credential is printed to STDOUT.  
+the user credential is printed to STDOUT.
 Otherwise the user credential is logged.
 
 ==== print_slice_expiration ====
@@ -1321,7 +1321,7 @@ Format: `omni.py listslivers <slice name>`
 Sample usage: `omni.py listslivers myslices`
 
 Return: String printout of slivers by aggregate, with the sliver expiration if known, AND
-a dictionary by aggregate URN of a dictionary by sliver URN of the sliver info records, 
+a dictionary by aggregate URN of a dictionary by sliver URN of the sliver info records,
 each of which is a dictionary possibly containing:
  - `SLIVER_INFO_URN`: URN of the sliver
  - `SLIVER_INFO_SLICE_URN`: Slice URN
@@ -1380,7 +1380,7 @@ Output directing options:
 Note that project membership is only supported at some `chapi` type
 clearinghouses, including the GENI Clearinghouse. Project membership
 determines who has rights to create a slice in the
-named project. 
+named project.
 
 ==== listslicemembers ====
 List all the members of the given slice, including their registered
@@ -1446,7 +1446,7 @@ Note also that adding a user to a slice does not automatically add
 their public SSH keys to resources that have already been reserved.
 
 ==== removeslicemember ====
-Remove the named user from the named slice. 
+Remove the named user from the named slice.
 
 Format: `omni.py removeslicemember <slice name> <user username>`
 
@@ -1475,9 +1475,9 @@ Format:  `omni.py [-a AM_URL_or_nickname] getversion`
 
 Sample Usage:
  * `omni.py getversion`
- * !GetVersion for only this aggregate: 
+ * !GetVersion for only this aggregate:
     `omni.py -a http://localhost:12348 getversion`
- * Save !GetVersion information to per-aggregate files: 
+ * Save !GetVersion information to per-aggregate files:
     `omni.py -o getversion`
 
 Aggregates queried:
@@ -1513,7 +1513,7 @@ Optional argument for AM API v1 & v2 is a slice name which returns a manifest RS
 Note that the slice name argument is only supported in AM API v1 and v2.
 For listing contents of a slice in AM API v3+, use `describe`.
 
-Format: 
+Format:
 {{{
     omni.py [-a AM_URL_or_nickname] [-o [-p fileprefix] or
                     --outputfile filename] \
@@ -1553,7 +1553,7 @@ It can save the result to a file so you can use an edited version of the result 
 create a reservation RSpec, suitable for use in a call to
 `createsliver` or `allocate`.
 
-If a slice name is supplied, then resources for that slice only 
+If a slice name is supplied, then resources for that slice only
 will be displayed.  In this case, the slice credential is usually
 retrieved from the Slice Authority. But
 with the `--slicecredfile` option it is read from the specified file, if it
@@ -1673,7 +1673,7 @@ Options for development and testing:
 ==== createsliver ====
 The GENI AM API `CreateSliver()` call: reserve resources at GENI aggregates.
 
-For use in AM API v1+2 only. 
+For use in AM API v1+2 only.
 For AM API v3+, use this sequence of three commands: `allocate`, `provision`, and `performoperationalaction`.
 
 Format:  `omni.py [-a AM_URL_or_nickname] createsliver <slice-name> <rspec filename or URL or nickname>`
@@ -1691,12 +1691,12 @@ Sample Usage:
      omni.py -a gpo-ig2 --api-version 1 createsliver \
               myslice resources.rspec
 }}}
- * Use a saved (possibly delegated) slice credential: 
+ * Use a saved (possibly delegated) slice credential:
 {{{
      omni.py --slicecredfile myslice-credfile.xml \
              -a gpo-ig createsliver myslice resources.rspec
 }}}
- * Save manifest RSpec to a file with a particular prefix: 
+ * Save manifest RSpec to a file with a particular prefix:
 {{{
      omni.py -a gpo-ig -o -p myPrefix \
              createsliver myslice resources.rspec
@@ -1713,7 +1713,7 @@ Sample Usage:
              createsliver myslices resources.rspec
 }}}
 
-Note: 
+Note:
 The request RSpec file argument should have been created by using
 availability information from a previous call to `listresources`
 (e.g. `omni.py -o listresources`). The file can be local or a remote URL.
@@ -1725,8 +1725,8 @@ When you call
 omni will try to read 'myrspec' by interpreting it in the following order:
 1. a URL or a file on the local filesystem
 2. an RSpec nickname specified in the omni_config
-3. a file in a location (file or url) defined as: 
-   `<default_rspec_server>/<rspec_nickname>.<default_rspec_extension>` 
+3. a file in a location (file or url) defined as:
+   `<default_rspec_server>/<rspec_nickname>.<default_rspec_extension>`
 where `<default_rspec_server>` and `<default_rspec_extension>` are defined in the omni_config.
 
 For help creating GENI RSpecs, see
@@ -1778,14 +1778,14 @@ compute resources.
 2 command-line options control this:
  - `--ignoreConfiguUsers`: When supplied, ignore the omni_config
  `users` and do not install any keys listed there.
- - `--noSliceMembers`: When supplied, over-ride the default 
+ - `--noSliceMembers`: When supplied, over-ride the default
  and do NOT contact the clearinghouse to retrieve slice members.
 The old (pre v2.7) option `--useSliceMembers` is deprecated, and has
 no effect - the behavior it enables is the default.
 You can also control this behavior using 2 settings in your
-`omni_config` file in the `omni` section. 
+`omni_config` file in the `omni` section.
  * Add the setting `useslicemembers=True` or `useslicemembers=False` to toggle retrieving
-   slice members' SSH keys. 
+   slice members' SSH keys.
  * Additionally, setting `ignoreconfigusers=True` has the same effect as
    including `--ignoreConfigUsers` as a commandline option.
 
@@ -1885,9 +1885,9 @@ Sample usage:
  calculated from the AM URL and slice name), using the slice
  credential saved in the given file. Provision in best effort mode
  to make sure as many resources as possible are provisioned.
-{{{ 
+{{{
      omni.py -V 3 -a http://myaggregate/url \
-	   -a http://myother/aggregate \ 
+	   -a http://myother/aggregate \
 	   --end-time 20120909 \
 	   -o --outputfile %s-provision-%a.json \
 	   --slicecredfile mysaved-myslice-slicecred.xml \
@@ -1898,7 +1898,7 @@ Sample usage:
 {{{
      omni.py -V 3 -a http://myaggregate/url \
 	         --sliver-urn urn:publicid:IDN+myam+sliver+1 \
-        	 --sliver-urn urn:publicid:IDN+myam+sliver+2 \ 
+        	 --sliver-urn urn:publicid:IDN+myam+sliver+2 \
 		 provision myslice
 }}}
 
@@ -1930,7 +1930,7 @@ Options:
  - `-t <type version>`: Specify a required manifest RSpec type and
  version to return. It skips any AM that doesn't advertise (in
  !GetVersion) that it supports that format. Default is "GENI
- 3". "ProtoGENI 2" is commonly supported as well. 
+ 3". "ProtoGENI 2" is commonly supported as well.
 
 Note that some aggregates may require provisioning all slivers in the same state at the same
 time, per the `geni_single_allocation` !GetVersion return.
@@ -1945,14 +1945,14 @@ compute resources.
 2 command-line options control this:
  - `--ignoreConfiguUsers': When supplied, ignore the omni_config
  `users` and do not install any keys listed there.
- - `--noSliceMembers`: When supplied, over-ride the default 
+ - `--noSliceMembers`: When supplied, over-ride the default
  and do NOT contact the clearinghouse to retrieve slice members.
 The old (pre v2.7) option `--useSliceMembers` is deprecated, and has
 no effect - the behavior it enables is the default.
 You can also control this behavior using 2 settings in your
-`omni_config` file in the `omni` section. 
+`omni_config` file in the `omni` section.
  * Add the setting `useslicemembers=True` or `useslicemembers=False` to toggle retrieving
-   slice members' SSH keys. 
+   slice members' SSH keys.
  * Additionally, setting `ignoreconfigusers=True` has the same effect as
    including `--ignoreConfigUsers` as a commandline option.
 
@@ -2083,7 +2083,7 @@ Calls the AM API v1 or v2 !RenewSliver function.  For AM API v3, see `renew` ins
 Format:  `omni.py [-a AM_URL_or_nickname] renewsliver <slice-name> "<time>"`
 
 Sample Usage:
- * Renew all slivers in slice, myslice, at all aggregates 
+ * Renew all slivers in slice, myslice, at all aggregates
     `omni.py renewsliver myslice "12/12/10 4:15pm"`
     `omni.py renewsliver myslice "12/12/10 16:15"`
  * Use AM API v1 to renew slivers in slice, myslice, at one aggregate
@@ -2231,7 +2231,7 @@ GENI AM API !SliverStatus function
 Format: `omni.py [-a AM_URL_or_nickname] sliverstatus <slice-name>`
 
 Sample Usage:
- * Run `sliverstatus` on all slivers in slice, myslice, at all aggregates 
+ * Run `sliverstatus` on all slivers in slice, myslice, at all aggregates
     `omni.py sliverstatus myslice`
  * Run `sliverstatus` on slivers in slice, myslice, at one aggregate
     `omni.py -a http://localhost:12348 sliverstatus myslice`
@@ -2268,7 +2268,7 @@ Options:
  - If `--tostdout` option, then instead of logging, print to STDOUT.
 
 ==== status ====
-AM API Status (slice name).  For use in AM API v3+. 
+AM API Status (slice name).  For use in AM API v3+.
 
 See `sliverstatus` for the AM API v1 and v2 equivalent.
 
@@ -2320,7 +2320,7 @@ Options for development and testing:
  - `--devmode`: Continue on error if possible
 
 ==== deletesliver ====
-Calls the AM API v1 and v2 !DeleteSliver function. 
+Calls the AM API v1 and v2 !DeleteSliver function.
 This command will free any resources associated with your slice at
 the given aggregates.
 
@@ -2329,7 +2329,7 @@ For AM API v3, see `delete`.
 Format: `omni.py [-a AM_URL_or_nickname] deletesliver <slice-name>`
 
 Sample Usage:
- * Delete all slivers in slice, myslice, at all aggregates 
+ * Delete all slivers in slice, myslice, at all aggregates
     `omni.py deletesliver myslice`
  * Delete slivers in slice, myslice, at one aggregate
     `omni.py -a http://localhost:12348 deletesliver myslice`
@@ -2352,7 +2352,7 @@ Aggregates acted on:
  - List of URNs and URLs provided by the selected clearinghouse
 
 ==== delete ====
-AM API Delete (slicename). For use in AM API v3+. 
+AM API Delete (slicename). For use in AM API v3+.
 For AM API v1 and v2, see `deletesliver`.
 
 Delete the named slivers, making them `geni_unallocated`. Resources are stopped
@@ -2424,7 +2424,7 @@ supporting later forensics / debugging.
 Format: `omni.py [-a AM_URL_or_nickname] shutdown <slice-name>`
 
 Sample Usage:
- * Shutdown all slivers in slice, myslice, at all aggregates 
+ * Shutdown all slivers in slice, myslice, at all aggregates
     `omni.py shutdown myslice`
  * Shutdown slivers in slice, myslice, at one aggregate
     `omni.py -a http://localhost:12348 shutdown myslice`
@@ -2452,11 +2452,11 @@ Aggregates queried:
 ==== update ====
 Call GENI AM API Update (Args: `<slice name> <rspec file name>`)
 
-For use with AM API v3+ only, and only at some AMs. 
-Technically adopted for AM API v4, but may be implemented by v3 AMs. 
+For use with AM API v3+ only, and only at some AMs.
+Technically adopted for AM API v4, but may be implemented by v3 AMs.
 See http://groups.geni.net/geni/wiki/GAPI_AM_API_DRAFT/Adopted#ChangeSetC:Update
 
-Update resources as described in a request RSpec argument in a slice with 
+Update resources as described in a request RSpec argument in a slice with
 the named URN. Update the named slivers if specified, or all slivers in the slice at the aggregate.
 On success, new resources in the RSpec will be allocated in new slivers, existing resources in the RSpec will
 be updated, and slivers requested but missing in the RSpec will be deleted.
@@ -2473,12 +2473,12 @@ Sample usage:
    `omni.py -V3 -a http://myaggregate/url -a http://myother/aggregate --end-time 20120909 -o --outputfile myslice-manifest-%a.json --slicecredfile mysaved-myslice-slicecred.xml update myslice my-update-rspec.xml`
 
 After update, slivers that were `geni_allocated` remain `geni_allocated` (unless they were left
-out of the RSpec, indicating they should be deleted, which is then immediate). Slivers that were 
+out of the RSpec, indicating they should be deleted, which is then immediate). Slivers that were
 `geni_provisioned` or `geni_updating` will be `geni_updating`.
 Clients must `Renew` or `Provision` any new (`geni_updating`) slivers before the expiration time
-(given in the return struct), or the aggregate will automatically revert the changes 
-(delete new slivers or revert changed slivers to their original state). 
-Slivers that were `geni_provisioned` that you do not include in the RSpec will be deleted, 
+(given in the return struct), or the aggregate will automatically revert the changes
+(delete new slivers or revert changed slivers to their original state).
+Slivers that were `geni_provisioned` that you do not include in the RSpec will be deleted,
 but only after calling `Provision`.
 Slivers that were `geni_allocated` or `geni_updating` are immediately changed.
 
@@ -2498,8 +2498,8 @@ Aggregates queried:
  - List of URLs given in omni_config `aggregates` option, if provided, ELSE
  - List of URNs and URLs provided by the selected clearinghouse
 Note that if multiple aggregates are supplied, the same RSpec will be submitted to each.
-Aggregates should ignore parts of the Rspec requesting specific non-local resources (bound requests), but each 
-aggregate should attempt to satisfy all unbound requests. 
+Aggregates should ignore parts of the Rspec requesting specific non-local resources (bound requests), but each
+aggregate should attempt to satisfy all unbound requests.
 
 Options:
  - `--sliver-urn` or `-u` option: each specifies a sliver URN to update. If specified,
@@ -2508,7 +2508,7 @@ Options:
    may not be updated, in which case check the geni_error return for that sliver.
    If not supplied, then if any slivers cannot be updated, the whole call fails
    and sliver allocation states do not change.
-   Note that some aggregates may require updating all slivers in the same state at the same 
+   Note that some aggregates may require updating all slivers in the same state at the same
    time, per the `geni_single_allocation` !GetVersion return.
  - `--end-time <time>`: Request that new slivers expire at the given time.
    The aggregates may provision the resources, but not be able to grant the requested
@@ -2539,11 +2539,11 @@ Options for development and testing:
 ==== cancel ====
 Call GENI AM API Cancel (slice name)
 
-For use with AM API v3+ only, and only at some AMs. 
-Technically adopted for AM API v4, but may be implemented by v3 AMs. 
+For use with AM API v3+ only, and only at some AMs.
+Technically adopted for AM API v4, but may be implemented by v3 AMs.
 See http://groups.geni.net/geni/wiki/GAPI_AM_API_DRAFT/Adopted#ChangeSetC:Update
 
-Cancel pending changes in a slice with 
+Cancel pending changes in a slice with
 the named URN. Cancel the changes to the named slivers if specified, or all slivers in the slice at the aggregate.
 On success, any slivers that were being allocated will be deleted
 (geni_unallocated), and any slivers that were being updated
@@ -2584,7 +2584,7 @@ Options:
    may not be canceled, in which case check the geni_error return for that sliver.
    If not supplied, then if any slivers cannot be canceled, the whole call fails
    and sliver allocation states do not change.
-   Note that some aggregates may require canceling all changes in the same state at the same 
+   Note that some aggregates may require canceling all changes in the same state at the same
    time, per the `geni_single_allocation` !GetVersion return.
 
 Output directing options:
@@ -2686,9 +2686,9 @@ See http://www.protogeni.net/trac/protogeni/wiki/ImageHowTo
 
 Format: `omni.py listimages [CREATORURN]`
 
-List the disk images created by the given user. 
-Takes a user urn or name. If no user is supplied, uses the caller's urn. 
-Returns a list of all images created by that user, including the URN 
+List the disk images created by the given user.
+Takes a user urn or name. If no user is supplied, uses the caller's urn.
+Returns a list of all images created by that user, including the URN
 for deleting the image. Return is a list of structs containing the `url` and `urn` of the iamge.
 Note that you should invoke this at the AM where the images were created.
 
@@ -2709,7 +2709,7 @@ Output directing options:
 
 ==== nicknames ====
 Print / return the known Aggregate and RSpec nicknames, as defined in
-the Omni config file(s). 
+the Omni config file(s).
 
 If you specify nicknames in `-a` arguments, it will look up that
 nickname and print any matching aggregate URN/URL.
@@ -2746,7 +2746,7 @@ Omni knows the following RSpec Nicknames:
 Print the expiration of any slivers in the given slice.
 Return is a string, and a struct by AM URL of the list of sliver expirations.
 
-Format: 
+Format:
 `omni.py [-a amURNOrNick] [--useSliceAggregates] [-u sliverurn] print_sliver_expirations mySlice`
 
 Sample output:
@@ -2763,7 +2763,7 @@ Note that PLC Web UI lists slices as `<site name>_<slice name>`
 Slice credential is usually retrieved from the Slice Authority. But
 with the `--slicecredfile` option it is read from that file, if it exists.
 
- - `--sliver-urn` / `-u` option: each specifies a sliver URN to get status on. If specified, 
+ - `--sliver-urn` / `-u` option: each specifies a sliver URN to get status on. If specified,
    only the listed slivers will be queried. Otherwise, all slivers in the slice will be queried.
 
 Aggregates queried:

--- a/src/gcf/omnilib/chhandler.py
+++ b/src/gcf/omnilib/chhandler.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import
 
 #----------------------------------------------------------------------
-# Copyright (c) 2012-2016 Raytheon BBN Technologies
+# Copyright (c) 2012-2017 Raytheon BBN Technologies
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and/or hardware specification (the "Work") to

--- a/src/gcf/omnilib/chhandler.py
+++ b/src/gcf/omnilib/chhandler.py
@@ -415,7 +415,8 @@ class CHCallHandler(object):
         Not supported by all frameworks.
 
         Return object is a list of structs, containing
-        PROJECT_URN, PROJECT_UID, EXPIRED, and PROJECT_ROLE. EXPIRED is a boolean.
+        PROJECT_URN, PROJECT_UID, PROJECT_EXPIRED, and PROJECT_ROLE.
+        PROJECT_EXPIRED is a boolean.
 
         Output directing options:
         -o Save result in a file
@@ -470,8 +471,8 @@ class CHCallHandler(object):
                 projectname = nameFromURN(project)
 
                 # Returning this key is non-standard..
-                if tup.has_key('EXPIRED'):
-                    exp = tup['EXPIRED']
+                if tup.has_key('PROJECT_EXPIRED'):
+                    exp = tup['PROJECT_EXPIRED']
                     if exp == True:
                         expired = True
                 if tup.has_key('PROJECT_ROLE'):

--- a/src/gcf/omnilib/chhandler.py
+++ b/src/gcf/omnilib/chhandler.py
@@ -80,7 +80,7 @@ class CHCallHandler(object):
     def _handle(self, args):
         if len(args) == 0:
             self._raise_omni_error('Insufficient number of arguments - Missing command to run')
-        
+
         call = args[0].lower()
         # disallow calling private methods
         if call.startswith('_'):
@@ -160,9 +160,9 @@ class CHCallHandler(object):
             aggCnt += 1
             agg_nickname = _lookupAggNick(self, urn)
             if agg_nickname:
-                pretty_result += "  Aggregate %d:\n \t%s \n \t%s \n \t%s\n" % (aggCnt, agg_nickname, urn, url) 
+                pretty_result += "  Aggregate %d:\n \t%s \n \t%s \n \t%s\n" % (aggCnt, agg_nickname, urn, url)
             else:
-                pretty_result += "  Aggregate %d:\n \t%s \n \t%s\n" % (aggCnt, urn, url) 
+                pretty_result += "  Aggregate %d:\n \t%s \n \t%s\n" % (aggCnt, urn, url)
             retVal[urn] = url
 
         # Save/print out result
@@ -217,11 +217,11 @@ class CHCallHandler(object):
                 self.logger.warn(msg + " - but continuing...")
             else:
                 self._raise_omni_error(msg)
-        
+
         (slice_cred, message) = _do_ssl(self.framework, None, "Create Slice %s" % urn, self.framework.create_slice, urn)
         if slice_cred:
             slice_exp = credutils.get_cred_exp(self.logger, slice_cred)
-            printStr = "Created slice with Name %s, URN %s, Expiration %s" % (name, urn, slice_exp) 
+            printStr = "Created slice with Name %s, URN %s, Expiration %s" % (name, urn, slice_exp)
             retVal += printStr+"\n"
             self.logger.info( printStr )
             if self.opts.api_version >= 3:
@@ -235,7 +235,7 @@ class CHCallHandler(object):
             success = urn
 
         else:
-            printStr = "Create Slice Failed for slice name %s." % (name) 
+            printStr = "Create Slice Failed for slice name %s." % (name)
             if message != "":
                 printStr += " " + message
             retVal += printStr+"\n"
@@ -244,7 +244,7 @@ class CHCallHandler(object):
             if not self.logger.isEnabledFor(logging.DEBUG):
                 self.logger.warn( "   Try re-running with --debug for more information." )
         return retVal, success
-        
+
     def renewslice(self, args):
         """Renew the slice at the clearinghouse so that the slivers can be
         renewed.
@@ -687,7 +687,7 @@ class CHCallHandler(object):
         e.g.:
           Get slice mytest credential from slice authority, save to a file:
             omni.py -o getslicecred mytest
-          
+
           Get slice mytest credential from slice authority, save to a file with prefix mystuff:
             omni.py -o -p mystuff getslicecred mytest
 
@@ -808,7 +808,7 @@ class CHCallHandler(object):
         at the clearinghouse. Note this is non-authoritative information.
         Argument: slice name or URN
         Return: String printout of slivers by aggregate, with the sliver expiration if known, AND
-        A dictionary by aggregate URN of a dictionary by sliver URN of the sliver info records, 
+        A dictionary by aggregate URN of a dictionary by sliver URN of the sliver info records,
         each of which is a dictionary possibly containing:
          - SLIVER_INFO_URN
          - SLIVER_INFO_SLICE_URN
@@ -1057,7 +1057,7 @@ class CHCallHandler(object):
 
     def removeslicemember(self, args):
         """Remove a user from a slice.
-        Args: slicename username 
+        Args: slicename username
         Return summary string and whether successful
         """
         if len(args) != 2 and len(args) != 3:
@@ -1095,4 +1095,3 @@ class CHCallHandler(object):
 
 #########
 ## Helper functions follow
-

--- a/src/gcf/omnilib/frameworks/framework_base.py
+++ b/src/gcf/omnilib/frameworks/framework_base.py
@@ -41,21 +41,21 @@ from ...sfa.trust.credential import Credential
 class Framework_Base():
     """
     Framework_Base is an abstract class that identifies the minimal set of functions
-    that must be implemented in order to add a control framework to omni.  
-    
+    that must be implemented in order to add a control framework to omni.
+
     Instructions for adding a new framework:
-    
+
     Create "framework_X" in the frameworks directory, where X is your control framework.
-    
+
     Create a Framework class in the file that inherits "Framework_Base" and fill out each of the functions.
-    
+
     Edit the sample "omni_config" file and add a section for your framework, giving the section
     the same name as X used in framework_X.  For instance, 'sfa' or 'gcf'.  Your framework's section
-    of the omni config *MUST* have a cert and key entry, which omni will use when talking to 
+    of the omni config *MUST* have a cert and key entry, which omni will use when talking to
     the GENI Aggregate managers.
-    
+
     """
-    
+
     def __init__(self, config):
         self.cert = getAbsPath(config['cert'])
         if not os.path.exists(self.cert):
@@ -78,7 +78,7 @@ class Framework_Base():
         --usercredfile to be handled properly.
         Returns the usercred - in XML string format.
         """
-        
+
         try:
             if self.user_cred_struct is not None:
                 pass
@@ -135,7 +135,7 @@ class Framework_Base():
             logger.info("NOT getting user credential from file %s - file doesn't exist or is empty", opts.usercredfile)
 
         return cred
-        
+
     def get_version(self):
         """
         Returns a dict of the GetVersion return from the control framework. And an error message if any.
@@ -147,14 +147,14 @@ class Framework_Base():
         Returns a user credential from the control framework as a string. And an error message if any.
         """
         raise NotImplementedError('get_user_cred')
-    
+
     def get_slice_cred(self, urn):
         """
         Retrieve a slice with the given urn and returns the signed credential as a string.
         """
         raise NotImplementedError('get_slice_cred')
-    
-    def create_slice(self, urn):    
+
+    def create_slice(self, urn):
         """
         If the slice already exists in the framework, it returns that.  Otherwise it creates the slice
         and returns the new slice as a string.
@@ -314,11 +314,11 @@ class Framework_Base():
     def add_member_to_slice(self, slice_urn, member_name, role = 'MEMBER'):
         raise NotImplementedError('add_member_to_slice')
 
-    # remove a member from a slice 
+    # remove a member from a slice
     def remove_member_from_slice(self, slice_urn, member_name):
         raise NotImplementedError('remove_member_from_slice')
 
-    # Record new slivers at the CH database 
+    # Record new slivers at the CH database
     # write new sliver_info to the database using chapi
     # Manifest is the XML when using APIv1&2 and none otherwise
     # expiration is the slice expiration
@@ -353,4 +353,3 @@ class Framework_Base():
     # Compare with list_sliverinfo_urns which only returns the sliver URNs
     def list_sliver_infos_for_slice(self, slice_urn):
         return {}
-        

--- a/src/gcf/omnilib/frameworks/framework_base.py
+++ b/src/gcf/omnilib/frameworks/framework_base.py
@@ -184,7 +184,8 @@ class Framework_Base():
     def list_my_projects(self, username):
         """
         '''List projects owned by the user (name or URN) provided, returning a list of structs, containing
-        PROJECT_URN, PROJECT_UID, EXPIRED, and PROJECT_ROLE. EXPIRED is a boolean.'''
+        PROJECT_URN, PROJECT_UID, PROJECT_EXPIRED, and PROJECT_ROLE.
+        PROJECT_EXPIRED is a boolean.'''
         """
         raise NotImplementedError('list_my_projects')
 

--- a/src/gcf/omnilib/frameworks/framework_base.py
+++ b/src/gcf/omnilib/frameworks/framework_base.py
@@ -1,5 +1,5 @@
 #----------------------------------------------------------------------
-# Copyright (c) 2011-2016 Raytheon BBN Technologies
+# Copyright (c) 2011-2017 Raytheon BBN Technologies
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and/or hardware specification (the "Work") to

--- a/src/gcf/omnilib/frameworks/framework_chapi.py
+++ b/src/gcf/omnilib/frameworks/framework_chapi.py
@@ -212,7 +212,7 @@ class Framework(Framework_Base):
         else:
             options['match'] = {'SERVICE_TYPE':"MEMBER_AUTHORITY"}
             self.logger.debug("Using API v2, with options: %s", options)
-            (res, message) = _do_ssl(self, None, ("List member authorities at %s %s" % (self.fwtype, self.ch_url)), 
+            (res, message) = _do_ssl(self, None, ("List member authorities at %s %s" % (self.fwtype, self.ch_url)),
                                      self.ch.lookup, "SERVICE", [],
                                      options)
         auths = dict()
@@ -273,7 +273,7 @@ class Framework(Framework_Base):
         self._sa_url = sas[sas.keys()[0]]
         return self._sa_url
 
-    # Add new speaks for options and credentials based on provided opts 
+    # Add new speaks for options and credentials based on provided opts
     def _add_credentials_and_speaksfor(self, credentials, options):
         # FIXME: Tune log messages
 #        self.logger.debug("add_c_n_spkfor start with self.opts.speaksfor = '%s'" % self.opts.speaksfor)
@@ -353,7 +353,7 @@ class Framework(Framework_Base):
                             self.user_cred = self.user_cred_struct['geni_value']
                             if self.user_cred_struct.has_key('geni_version'):
                                 if not isinstance(self.user_cred_struct['geni_version'], str):
-                                    self.logger.debug("Got non string geni_version on user cred. %s is type %s", 
+                                    self.logger.debug("Got non string geni_version on user cred. %s is type %s",
                                                       self.user_cred_struct['geni_version'], type(self.user_cred_struct['geni_version']))
                                     self.user_cred_struct['geni_version'] = str(self.user_cred_struct['geni_version'])
                     if self.user_cred is None:
@@ -383,7 +383,7 @@ class Framework(Framework_Base):
 
     def get_slice_cred(self, slice_urn, struct=False):
         scred = []
-        options = {'match': 
+        options = {'match':
                    {'SLICE_URN': slice_urn,
                     'SLICE_EXPIRED': False,
                     }}
@@ -399,7 +399,7 @@ class Framework(Framework_Base):
         # This call is the same for CHAPI v1 and V2
         (res, message) = _do_ssl(self, None, ("Get credentials for slice %s on %s SA %s" % (slice_urn,
                                                                                             self.fwtype, self.sa_url())),
-                                 self.sa().get_credentials, slice_urn, scred, 
+                                 self.sa().get_credentials, slice_urn, scred,
                                  options)
 
         # FIXME: Handle typical error return codes with special messages
@@ -475,10 +475,10 @@ class Framework(Framework_Base):
                                      scred,
                                      options)
         else:
-            (res, message) = _do_ssl(self, None, 
+            (res, message) = _do_ssl(self, None,
                                      ("Get %s SSH keys from %s %s" % (username, self.fwtype, self.ma_url())),
                                      self.ma().lookup,
-                                     "KEY", 
+                                     "KEY",
                                      scred, options)
             # In V1, we get a dictionary of KEY_MEMBER => KEY_PUBLIC, KEY_PRIVATE
             # In V2, we get a dictionary of KEY_ID => KEY_MEMBER, KEY_PUBLIC, KEY_PRIVATE
@@ -586,7 +586,7 @@ class Framework(Framework_Base):
                               name = project).urn_string()
             self.logger.debug("Built project_urn '%s'", project_urn)
 
-        options = {'fields': 
+        options = {'fields':
                    {'SLICE_NAME': slice_name,
                     }}
         if project_urn is not None:
@@ -646,9 +646,9 @@ class Framework(Framework_Base):
         scred, options = self._add_credentials_and_speaksfor(scred, options)
 
         # This call is the same in V1 and V2
-        (res, message) = _do_ssl(self, None, 
+        (res, message) = _do_ssl(self, None,
                                  ("Get credentials for slice %s on %s %s" % (slice_name, self.fwtype, self.sa_url())),
-                                 self.sa().get_credentials, slice_urn, scred, 
+                                 self.sa().get_credentials, slice_urn, scred,
                                  options)
 
         cred = None
@@ -732,7 +732,7 @@ class Framework(Framework_Base):
         if not is_valid_urn_bytype(slice_urn, 'slice', self.logger):
             return "%s does not support deleting slices. (And slice urn %s invalid)" % (self.fwtype, slice_urn)
 
-        options = {'match': 
+        options = {'match':
                    {'SLICE_URN': slice_urn,
                     'SLICE_EXPIRED': False,
                     }}
@@ -794,13 +794,13 @@ class Framework(Framework_Base):
         # TODO: list of field names from getVersion - should we get all or assume we have URN and URL
         options = {'filter':['SERVICE_URN', 'SERVICE_URL']}
         if not self.speakV2:
-            (res, message) = _do_ssl(self, None, ("List Aggregates at %s %s" % (self.fwtype, self.ch_url)), 
+            (res, message) = _do_ssl(self, None, ("List Aggregates at %s %s" % (self.fwtype, self.ch_url)),
                                      self.ch.lookup_aggregates,
                                      options
                                      )
         else:
             options['match']= {'SERVICE_TYPE' : 'AGGREGATE_MANAGER'}
-            (res, message) = _do_ssl(self, None, ("List Aggregates at %s %s" % (self.fwtype, self.ch_url)), 
+            (res, message) = _do_ssl(self, None, ("List Aggregates at %s %s" % (self.fwtype, self.ch_url)),
                                      self.ch.lookup, "SERVICE",
                                      [], options # Empty credential list
                                      )
@@ -835,16 +835,16 @@ class Framework(Framework_Base):
 
         userurn = self.member_name_to_urn(user)
 
-        options = {'match': 
+        options = {'match':
                    {'SLICE_EXPIRED': False, # Seems to be ignored
                         }}
         scred, options = self._add_credentials_and_speaksfor(scred, options)
 
         if not self.speakV2:
-            (res, message) = _do_ssl(self, None, ("List Slices for %s at %s %s" % (user, self.fwtype, self.sa_url())), 
+            (res, message) = _do_ssl(self, None, ("List Slices for %s at %s %s" % (user, self.fwtype, self.sa_url())),
                                      self.sa().lookup_slices_for_member, userurn, scred, options)
         else:
-            (res, message) = _do_ssl(self, None, ("List Slices for %s at %s %s" % (user, self.fwtype, self.sa_url())), 
+            (res, message) = _do_ssl(self, None, ("List Slices for %s at %s %s" % (user, self.fwtype, self.sa_url())),
                                      self.sa().lookup_for_member, "SLICE", userurn, scred, options)
 
 
@@ -905,10 +905,10 @@ class Framework(Framework_Base):
         scred, options = self._add_credentials_and_speaksfor(scred, options)
 
         if not self.speakV2:
-            (res, message) = _do_ssl(self, None, ("List Projects for %s at %s %s" % (user, self.fwtype, self.sa_url())), 
+            (res, message) = _do_ssl(self, None, ("List Projects for %s at %s %s" % (user, self.fwtype, self.sa_url())),
                                      self.sa().lookup_projects_for_member, userurn, scred, options)
         else:
-            (res, message) = _do_ssl(self, None, ("List Projects for %s at %s %s" % (user, self.fwtype, self.sa_url())), 
+            (res, message) = _do_ssl(self, None, ("List Projects for %s at %s %s" % (user, self.fwtype, self.sa_url())),
                                      self.sa().lookup_for_member, "PROJECT", userurn, scred, options)
 
         projects = None
@@ -1087,7 +1087,7 @@ class Framework(Framework_Base):
             uc, msg = self.get_user_cred(True)
             if uc is not None:
                 scred.append(uc)
-        options = {'match': 
+        options = {'match':
                    {'SLICE_URN': urn,
                     'SLICE_EXPIRED': False,
                     }}
@@ -1172,12 +1172,12 @@ class Framework(Framework_Base):
         scred, options = self._add_credentials_and_speaksfor(scred, options)
 
         if not self.speakV2:
-            (res, message) = _do_ssl(self, None, 
-                                     ("Renew slice %s on %s %s until %s" % (urn, self.fwtype, self.sa_url(), expiration_dt)), 
+            (res, message) = _do_ssl(self, None,
+                                     ("Renew slice %s on %s %s until %s" % (urn, self.fwtype, self.sa_url(), expiration_dt)),
                                      self.sa().update_slice, urn, scred, options)
         else:
-            (res, message) = _do_ssl(self, None, 
-                                     ("Renew slice %s on %s %s until %s" % (urn, self.fwtype, self.sa_url(), expiration_dt)), 
+            (res, message) = _do_ssl(self, None,
+                                     ("Renew slice %s on %s %s until %s" % (urn, self.fwtype, self.sa_url(), expiration_dt)),
                                      self.sa().update, "SLICE", urn, scred, options)
 
         b = False
@@ -1375,7 +1375,7 @@ class Framework(Framework_Base):
             # rights on it
             return ([], "Error looking up slice %s - check the logs" % slice_urn)
 
-        options = {'match': 
+        options = {'match':
                    {'SLICE_URN': slice_urn,
                     'SLICE_EXPIRED': False,  # FIXME: This gets ignored
                     }}
@@ -1383,11 +1383,11 @@ class Framework(Framework_Base):
         creds, options = self._add_credentials_and_speaksfor(creds, options)
         if not self.speakV2:
             res, mess = _do_ssl(self, None, "Looking up %s slice %s members at %s" % (self.fwtype, slice_urn, self.sa_url()),
-                                self.sa().lookup_slice_members, slice_urn, 
+                                self.sa().lookup_slice_members, slice_urn,
                                 creds, options)
         else:
             res, mess = _do_ssl(self, None, "Looking up %s slice %s members at %s" % (self.fwtype, slice_urn, self.sa_url()),
-                                self.sa().lookup_members, "SLICE", slice_urn, 
+                                self.sa().lookup_members, "SLICE", slice_urn,
                                 creds, options)
         members = []
         logr = self._log_results((res, mess), 'Get members for %s slice %s%s' % (self.fwtype, slice_urn, expmess))
@@ -1427,7 +1427,7 @@ class Framework(Framework_Base):
             if uc is not None:
                 creds.append(uc)
 
-        options = {'match': 
+        options = {'match':
                    {'PROJECT_URN': project_urn,
                     'PROJECT_EXPIRED': False,  # FIXME: This gets ignored
                     }}
@@ -1435,11 +1435,11 @@ class Framework(Framework_Base):
         creds, options = self._add_credentials_and_speaksfor(creds, options)
         if not self.speakV2:
             res, mess = _do_ssl(self, None, "Looking up %s project %s members at %s" % (self.fwtype, project_urn, self.sa_url()),
-                                self.sa().lookup_project_members, project_urn, 
+                                self.sa().lookup_project_members, project_urn,
                                 creds, options)
         else:
             res, mess = _do_ssl(self, None, "Looking up %s project %s members at %s" % (self.fwtype, project_urn, self.sa_url()),
-                                self.sa().lookup_members, "PROJECT", project_urn, 
+                                self.sa().lookup_members, "PROJECT", project_urn,
                                 creds, options)
         members = []
         logr = self._log_results((res, mess), 'Get members for %s project %s' % (self.fwtype, project_urn))
@@ -1518,7 +1518,7 @@ class Framework(Framework_Base):
                                 slice_urn, creds, options)
         else:
             res, mess = _do_ssl(self, None, "Removing member %s from %s slice %s at %s" %  (member_urn, self.fwtype, slice_urn, self.sa_url()),
-                                self.sa().modify_membership, "SLICE", 
+                                self.sa().modify_membership, "SLICE",
                                 slice_urn, creds, options)
 
         logr = self._log_results((res, mess), 'Remove member %s from %s slice %s' % (member_urn, self.fwtype, slice_urn))
@@ -2001,7 +2001,7 @@ class Framework(Framework_Base):
                                     self.sa().lookup, "SLIVER_INFO", creds, options)
 
         logr = self._log_results((res, mess), "Find slivers for slice %s%s" % (slice_urn,expmess))
- 
+
         if logr == True:
             for sliver_urn, sliver_info in res['value'].items():
                 self.logger.debug("Slice '%s' found sliver '%s': %s", slice_urn, sliver_urn, sliver_info)

--- a/src/gcf/omnilib/frameworks/framework_chapi.py
+++ b/src/gcf/omnilib/frameworks/framework_chapi.py
@@ -1,5 +1,5 @@
 #----------------------------------------------------------------------
-# Copyright (c) 2011-2016 Raytheon BBN Technologies
+# Copyright (c) 2011-2017 Raytheon BBN Technologies
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and/or hardware specification (the "Work") to

--- a/src/gcf/omnilib/frameworks/framework_chapi.py
+++ b/src/gcf/omnilib/frameworks/framework_chapi.py
@@ -875,8 +875,8 @@ class Framework(Framework_Base):
                     continue
                 slicename = slice
                 # Returning this key is non-standard..
-                if tup.has_key('EXPIRED'):
-                    exp = tup['EXPIRED']
+                if tup.has_key('SLICE_EXPIRED'):
+                    exp = tup['SLICE_EXPIRED']
                     if exp == True:
                         self.logger.debug("Skipping expired slice %s", slice)
                         continue
@@ -885,7 +885,8 @@ class Framework(Framework_Base):
 
     def list_my_projects(self, user):
         '''List projects owned by the user (name or URN) provided, returning a list of structs, containing
-        PROJECT_URN, PROJECT_UID, EXPIRED, and PROJECT_ROLE. EXPIRED is a boolean.'''
+        PROJECT_URN, PROJECT_UID, PROJECT_EXPIRED, and PROJECT_ROLE.
+        PROJECT_EXPIRED is a boolean.'''
 
         if not self.useProjects:
             msg = "%s at %s does not support projects: no projects to list" % (self.fwtype, self.sa_url())

--- a/src/gcf/oscript.py
+++ b/src/gcf/oscript.py
@@ -37,7 +37,7 @@ from __future__ import absolute_import
 
     Typical usage:
     omni.py sfa listresources
-    
+
     The currently supported control frameworks (clearinghouse implementations)
     are SFA (i.e. PlanetLab), PG and GCF.
 
@@ -99,10 +99,10 @@ from __future__ import absolute_import
        [string listOfMemberDictionaries (PROJECT_MEMBER (URN), EMAIL, PROJECT_ROLE, PROJECT_MEMBER_UID)] = omni.py listprojectmembers PROJECTNAME
        [string listOfMemberDictionaries (KEYS, URN, EMAIL, ROLE)] = omni.py listslicemembers SLICENAME
        [string Boolean] = omni.py addslicemember SLICENAME USER [ROLE]
-       [string Boolean] = omni.py removeslicemember SLICENAME USER 
+       [string Boolean] = omni.py removeslicemember SLICENAME USER
 
       Other functions:
-       [string dictionary] = omni.py nicknames # List aggregate and rspec nicknames    
+       [string dictionary] = omni.py nicknames # List aggregate and rspec nicknames
        [string dictionary] = omni.py print_sliver_expirations SLICENAME
 """
 
@@ -134,8 +134,8 @@ from .omnilib.frameworks import framework_sfa
 from .omnilib.frameworks import framework_chapi
 from .gcf_version import GCF_VERSION
 
-#DEFAULT_RSPEC_LOCATION = "http://www.gpolab.bbn.com/experiment-support"               
-#DEFAULT_RSPEC_EXTENSION = "xml"                
+#DEFAULT_RSPEC_LOCATION = "http://www.gpolab.bbn.com/experiment-support"
+#DEFAULT_RSPEC_EXTENSION = "xml"
 
 def countSuccess( successList, failList ):
     """Intended to be used with 'renewsliver', 'deletesliver', and
@@ -172,7 +172,7 @@ def load_agg_nick_config(opts, logger):
 
     # Load up the config file
     configfiles = [os.path.join(parent_dir, 'agg_nick_cache.base')]
-    
+
     aggNickCacheExists = False
     # if aggNickCacheName defined on commandline exists, check it first
     if os.path.exists( opts.aggNickCacheName ):
@@ -196,10 +196,10 @@ def load_agg_nick_config(opts, logger):
 
     readConfigFile = False
     # Find the first valid config file
-    for cf in configfiles:         
+    for cf in configfiles:
         filename = os.path.expanduser(cf)
         if os.path.exists(filename):
-            config = {}       
+            config = {}
 
             # Did we find a valid config file?
             if not os.path.exists(filename):
@@ -275,7 +275,7 @@ def load_config(opts, logger, config={}, filename=None):
         filename = locate_config(opts, logger, config)
 
     logger.info("Loading config file '%s'", filename)
-    
+
     confparser = ConfigParser.RawConfigParser()
     try:
         confparser.read(filename)
@@ -288,13 +288,13 @@ def load_config(opts, logger, config={}, filename=None):
     config['omni'] = {}
     for (key,val) in confparser.items('omni'):
         config['omni'][key] = val
-        
-    # Load up the users the user wants us to see        
+
+    # Load up the users the user wants us to see
     config['users'] = []
     if 'users' in config['omni']:
         if config['omni']['users'].strip() is not '' :
             for user in config['omni']['users'].split(','):
-                if user.strip() is not '' : 
+                if user.strip() is not '' :
                     d = {}
                     for (key,val) in confparser.items(user.strip()):
                         d[key] = val
@@ -314,9 +314,9 @@ def load_config(opts, logger, config={}, filename=None):
             if temp == "":
                 continue
             if key == "default_rspec_location":
-                config['default_rspec_location'] = temp      
+                config['default_rspec_location'] = temp
             elif key == "default_rspec_extension":
-                config['default_rspec_extension'] = temp                
+                config['default_rspec_extension'] = temp
             else:
                 config['rspec_nicknames'][key] = temp
 
@@ -363,7 +363,7 @@ def load_config(opts, logger, config={}, filename=None):
     if not confparser.has_section(cf):
         logger.error("Missing framework '%s' in configuration file" % cf )
         raise OmniError, "Missing framework '%s' in configuration file" % cf
-    
+
     # Copy the control framework into a dictionary
     config['selected_framework'] = {}
     for (key,val) in confparser.items(cf):
@@ -470,7 +470,7 @@ def load_framework(config, opts):
     framework_mod = __import__('%s.omnilib.frameworks.framework_%s' % (prefix, cf_type), fromlist=['%s.omnilib.frameworks' % (prefix)])
     config['selected_framework']['logger'] = config['logger']
     framework = framework_mod.Framework(config['selected_framework'], opts)
-    return framework    
+    return framework
 
 def update_agg_nick_cache( opts, logger ):
     """Try to download the definitive version of `agg_nick_cache` and
@@ -601,8 +601,8 @@ def call(argv, options=None, verbose=False, dictLoggingConfig=None):
     not supplied, any logging config filename provided using the option --logconfig will be applied.
     Callers can control omni logs (suppressing console printing for example) using python logging.
 
-    Return is a list of 2 items: a human readable string summarizing the result 
-    (possibly an error message), and the result object (may be None on error). The result 
+    Return is a list of 2 items: a human readable string summarizing the result
+    (possibly an error message), and the result object (may be None on error). The result
     object type varies by underlying command called.
 
     Can call functions like this:
@@ -827,11 +827,11 @@ def getOptsUsed(parser, opts, logger=None):
     return nondef
 
 def API_call( framework, config, args, opts, verbose=False ):
-    """Call the function from the given args list. 
+    """Call the function from the given args list.
     Apply the options from the given optparse.Values opts argument
     If verbose, print the command and the summary.
-    Return is a list of 2 items: a human readable string summarizing the result 
-    (possibly an error message), and the result object (may be None on error). The result 
+    Return is a list of 2 items: a human readable string summarizing the result
+    (possibly an error message), and the result object (may be None on error). The result
     object type varies by underlying command called.
     """
 
@@ -874,7 +874,7 @@ def API_call( framework, config, args, opts, verbose=False ):
 #        print retItem
         logger.info( " " + "="*54 )
     # end of if verbose
-    
+
     return retVal, retItem
 
 def configure_logging(opts, dictConfig=None):
@@ -910,7 +910,7 @@ def configure_logging(opts, dictConfig=None):
     if opts.debug:
         level = logging.DEBUG
         optlevel = 'DEBUG'
-    
+
     deft = {}
 
     # Add the ability to use %(logfilename)s in the logging config
@@ -1069,7 +1069,7 @@ def getParser():
                       help="Config file name (aka `omni_config`)", metavar="FILE")
     basicgroup.add_option("-f", "--framework", default=os.getenv("GENI_FRAMEWORK", ""),
                       help="Control framework to use for creation/deletion of slices")
-    basicgroup.add_option("-r", "--project", 
+    basicgroup.add_option("-r", "--project",
                       help="Name of project. (For use with pgch framework.)")
     basicgroup.add_option("--alap", action="store_true", default=False,
                           help="Request slivers be renewed as close to the requested time as possible, instead of failing if the requested time is not possible. Default is False.")
@@ -1151,10 +1151,10 @@ def getParser():
     filegroup.add_option("--outputfile",  default=None, metavar="OUTPUT_FILENAME",
                       help="Name of file to write output to (instead of Omni picked name). '%a' will be replaced by servername, '%s' by slicename if any. Implies -o. Note that for multiple aggregates, without a '%a' in the name, only the last aggregate output will remain in the file. Will ignore -p.")
     filegroup.add_option("--usercredfile", default=os.getenv("GENI_USERCRED", None), metavar="USER_CRED_FILENAME",
-                      help="Name of user credential file to read from if it exists, or save to when running like '--usercredfile " + 
+                      help="Name of user credential file to read from if it exists, or save to when running like '--usercredfile " +
                          "myUserCred.xml -o getusercred'. Defaults to value of 'GENI_USERCRED' environment variable if defined.")
     filegroup.add_option("--slicecredfile", default=os.getenv("GENI_SLICECRED", None), metavar="SLICE_CRED_FILENAME",
-                      help="Name of slice credential file to read from if it exists, or save to when running like '--slicecredfile " + 
+                      help="Name of slice credential file to read from if it exists, or save to when running like '--slicecredfile " +
                          "mySliceCred.xml -o getslicecred mySliceName'. Defaults to value of 'GENI_SLICECRED' environment variable if defined.")
     parser.add_option_group( filegroup )
 
@@ -1221,7 +1221,7 @@ def getParser():
                       help="In AM API v2, if an AM returns a non-0 (failure) result code, raise an AMAPIError. Default is %default. For use by scripts.")
     devgroup.add_option("--maxBusyRetries", default=4, action="store", type="int",
                       help="Max times to retry AM or CH calls on getting a 'busy' error. Default: %default")
-    devgroup.add_option("--no-compress", dest='geni_compressed', 
+    devgroup.add_option("--no-compress", dest='geni_compressed',
                       default=True, action="store_false",
                       help="Do not compress returned values")
     devgroup.add_option("--abac", default=False, action="store_true",
@@ -1287,7 +1287,7 @@ def parse_args(argv, options=None, parser=None):
     try:
         indays = int(options.GetVersionCacheAge)
     except Exception, e:
-        raise OmniError, "Failed to parse GetVersionCacheAge: %s" % e 
+        raise OmniError, "Failed to parse GetVersionCacheAge: %s" % e
     options.GetVersionCacheOldestDate = datetime.datetime.utcnow() - datetime.timedelta(days=indays)
 
     options.getversionCacheName = os.path.normcase(os.path.expanduser(options.getversionCacheName))
@@ -1300,7 +1300,7 @@ def parse_args(argv, options=None, parser=None):
     try:
         indays = int(options.AggNickCacheAge)
     except Exception, e:
-        raise OmniError, "Failed to parse AggNickCacheAge: %s" % e 
+        raise OmniError, "Failed to parse AggNickCacheAge: %s" % e
     options.AggNickCacheOldestDate = datetime.datetime.utcnow() - datetime.timedelta(days=indays)
 
     options.aggNickCacheName = os.path.normcase(os.path.expanduser(options.aggNickCacheName))

--- a/src/gcf/oscript.py
+++ b/src/gcf/oscript.py
@@ -89,8 +89,8 @@ from __future__ import absolute_import
        [string Boolean] = omni.py deleteslice SLICENAME
        [string listOfSliceURNs] = omni.py listslices USER
        [string listOfSliceURNs] = omni.py listmyslices USER
-       [string listOfProjectDictionaries (PROJECT_URN, PROJECT_UID, PROJECT_ROLE, EXPIRED)] = omni.py listprojects USER
-       [string listOfProjectDictionaries (PROJECT_URN, PROJECT_UID, PROJECT_ROLE, EXPIRED)] = omni.py listmyprojects USER
+       [string listOfProjectDictionaries (PROJECT_URN, PROJECT_UID, PROJECT_ROLE, PROJECT_EXPIRED)] = omni.py listprojects USER
+       [string listOfProjectDictionaries (PROJECT_URN, PROJECT_UID, PROJECT_ROLE, PROJECT_EXPIRED)] = omni.py listmyprojects USER
        [string listOfSSHKeyPairs] = omni.py listmykeys
        [string listOfSSHKeyPairs] = omni.py listkeys USER
        [string stringCred] = omni.py getusercred

--- a/src/gcf/oscript.py
+++ b/src/gcf/oscript.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #----------------------------------------------------------------------
-# Copyright (c) 2011-2016 Raytheon BBN Technologies
+# Copyright (c) 2011-2017 Raytheon BBN Technologies
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and/or hardware specification (the "Work") to


### PR DESCRIPTION
The clearinghouse fixed a bug with the spelling of EXPIRED. Use the new keywords to be compatible with the latest clearinghouse code.

While there, remove trailing whitespace and update copyrights on the affected files. Don't worry about pycodestyle warnings, there are too many.

Fixes #915 