### PR TITLE
Added optional support for custom_request_handler_class to AMs

### DIFF
--- a/src/gcf-am.py
+++ b/src/gcf-am.py
@@ -182,6 +182,12 @@ def main(argv=None):
     # certs possibly concatenated together
     comboCertsFile = geni.CredentialVerifier.getCAsFileFromDir(getAbsPath(opts.rootcadir))
 
+    try:
+        custom_request_handler_class = delegate.custom_request_handler_class
+    except AttributeError:
+        # no custom request handler
+        custom_request_handler_class = None
+
     if opts.api_version == 1:
         # rootcadir is dir of multiple certificates
         delegate = geni.ReferenceAggregateManager(getAbsPath(opts.rootcadir))
@@ -200,7 +206,8 @@ def main(argv=None):
                                                      base_name=config['global']['base_name'], 
                                                      authorizer=authorizer,
                                                      resource_manager=resource_manager,
-                                                     delegate=delegate)
+                                                     delegate=delegate,
+                                                     custom_request_handler_class = custom_request_handler_class)
     elif opts.api_version == 3:
         ams = gcf.geni.am.am3.AggregateManagerServer((opts.host, int(opts.port)),
                                                      keyfile=keyfile,
@@ -210,7 +217,8 @@ def main(argv=None):
                                                      base_name=config['global']['base_name'],
                                                      authorizer=authorizer,
                                                      resource_manager=resource_manager,
-                                                     delegate=delegate, multithread=multithread)
+                                                     delegate=delegate, multithread=multithread,
+                                                     custom_request_handler_class = custom_request_handler_class)
     else:
         msg = "Unknown API version: %d. Valid choices are \"1\", \"2\", or \"3\""
         sys.exit(msg % (opts.api_version))

--- a/src/gcf/geni/am/am2.py
+++ b/src/gcf/geni/am/am2.py
@@ -854,7 +854,8 @@ class AggregateManagerServer(object):
                  trust_roots_dir=None,
                  ca_certs=None, base_name=None,
                  authorizer=None, resource_manager=None,
-                 delegate=None):
+                 delegate=None,
+                 custom_request_handler_class = None):
         # ca_certs arg here must be a file of concatenated certs
         if ca_certs is None:
             raise Exception('Missing CA Certs')
@@ -867,8 +868,12 @@ class AggregateManagerServer(object):
             delegate = ReferenceAggregateManager(trust_roots_dir, base_name, 
                                                  server_url)
         # FIXME: set logRequests=true if --debug
-        self._server = SecureXMLRPCServer(addr, keyfile=keyfile,
-                                          certfile=certfile, ca_certs=ca_certs)
+        if custom_request_handler_class is not None:
+            self._server = SecureXMLRPCServer(addr, requestHandler=custom_request_handler_class, keyfile=keyfile,
+                                              certfile=certfile, ca_certs=ca_certs)
+        else:
+            self._server = SecureXMLRPCServer(addr, keyfile=keyfile,
+                                              certfile=certfile, ca_certs=ca_certs)
         aggregate_manager = AggregateManager(trust_roots_dir, delegate, 
                                              authorizer, resource_manager)
         self._server.register_instance(aggregate_manager)


### PR DESCRIPTION
These changes allow an AM implementation to specify a custom request_handler_class to ``SecureXMLRPCServer``. (By adding a static class variable ``custom_request_handler_class`` to the class specified as ``delegate`` in the config.)

I've used this to add a non XML-RPC site and web service to the AM (both using the same client SSL authentication as the AM).

The small changes in this pull request are quite generic and don't change anything if you don't add ``custom_request_handler_class`` to the delegate. So it might be useful to add them.