### PR TITLE
Tweek logging to make it more useful to track errors on a production service

### DIFF
--- a/src/gcf/geni/am/am_method_context.py
+++ b/src/gcf/geni/am/am_method_context.py
@@ -24,6 +24,7 @@
 from __future__ import absolute_import
 
 import os
+import logging
 import traceback
 
 from ...sfa.trust.gid import GID
@@ -160,8 +161,13 @@ class AMMethodContext:
             self._logger.error("Generic Error of type %s in %s" % (str(type),self._method_name))
             self._handleError(value)
 
-        self._logger.info("Result from %s: %s", self._method_name, 
-                          self._result)
+        if self._logger.isEnabledFor(logging.DEBUG):
+            self._logger.info("Result from %s: %s", self._method_name,
+                              self._result)
+        else:
+            self._logger.info("Result from %s: %s... (turn on debug to get all the output)",
+                              self._method_name,
+                              str(self._result)[0:800])
 
     # Return a GENI_style error return for given exception/traceback
     def _errorReturn(self, e):

--- a/src/gcf/geni/am/am_method_context.py
+++ b/src/gcf/geni/am/am_method_context.py
@@ -157,7 +157,7 @@ class AMMethodContext:
             self._logger.exception("AM API Error in %s" % self._method_name)
             self._result=self._api_error(value);
         elif type:
-            self._logger.error("Generic Error in %s" % self._method_name)
+            self._logger.error("Generic Error of type %s in %s" % (str(type),self._method_name))
             self._handleError(value)
 
         self._logger.info("Result from %s: %s", self._method_name, 


### PR DESCRIPTION
The default behaviour trashes the log file with large blobs of compressed results for calls to ListResources, and warns of failure with too little information for debug. This PR changes the balance.