### PR TITLE
V2.11

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
 # Note: keep this file in wiki format for easy pasting to the gcf wiki
 
+gcf 2.11
+ * Support for newer openssl options in python2. Deprecate older versions
+
 gcf 2.10:
  * Changed references to trac.gpolab.bbn.com to point to Github.
    Although those pages mostly still reference trac, that is the future home.

--- a/README-omni.txt
+++ b/README-omni.txt
@@ -40,6 +40,9 @@ For the latest Omni documentation, examples, and trouble shooting
 tips, see the Omni Wiki: https://github.com/GENI-NSF/geni-tools/wiki/Omni
 
 == Release Notes ==
+New in v2.11
+ * Due to the chnages in the underlying OpenSSL versions some minor changes to SSL protocol versions were implemented.
+   These changes were needed to make omni run on newer Operating Systems using the updated OpenSSL version
 
 New in v2.10:
  * Continue anyway if no aggregate nickname cache can be loaded. (#822)

--- a/src/gcf/geni/SecureXMLRPCServer.py
+++ b/src/gcf/geni/SecureXMLRPCServer.py
@@ -97,8 +97,8 @@ class SecureXMLRPCServer(SimpleXMLRPCServer):
                                       certfile=certfile,
                                       server_side=True,
                                       cert_reqs=ssl.CERT_REQUIRED,
-#                                      ssl_version=ssl.PROTOCOL_TLSv1,
-                                      ssl_version=ssl.PROTOCOL_SSLv23, # Ideally we'd accept any TLS but no SSL. Sigh.
+                                      ssl_version=ssl.PROTOCOL_TLS,
+#                                      ssl_version=ssl.PROTOCOL_SSLv23, # Ideally we'd accept any TLS but no SSL. Sigh.
                                       ca_certs=ca_certs)
 #                                      ciphers='HIGH:MEDIUM:!ADH:!SSLv2:!MD5:!RC4:@STRENGTH') # Hopefully this effectively excludes SSLv2 and 3?
         if bind_and_activate:

--- a/src/gcf/geni/util/secure_xmlrpc_client.py
+++ b/src/gcf/geni/util/secure_xmlrpc_client.py
@@ -32,7 +32,7 @@ class SafeTransportWithCert(xmlrpclib.SafeTransport):
     a client X509 identity certificate.'''
 
     def __init__(self, use_datetime=0, keyfile=None, certfile=None,
-                 timeout=None, ssl_version=ssl.PROTOCOL_TLSv1, ciphers=None):
+                 timeout=None, ssl_version=ssl.PROTOCOL_TLS, ciphers=None):
         # Ticket #776: As of Python 2.7.9, server certs are verified by default.
         # But we don't have those. To preserve old functionality with new python,
         # pass an explicit context
@@ -80,10 +80,10 @@ class SafeTransportWithCert(xmlrpclib.SafeTransport):
             conn.ciphers = self.ciphers
         return conn
 
-# A custom HTTPSConnection that calls ssl.wrap_socket specifying the desired ssl_version, defaulting to PROTOCOL_TLSv1 instead of PROTOTOCOL_SSLv23
+# A custom HTTPSConnection that calls ssl.wrap_socket specifying the desired ssl_version, defaulting to PROTOCOL_TLS instead of PROTOTOCOL_SSLv23
 # Used directly by our SafeTransport, and indirectly by the below TLS1P26HTTPS
 class TLS1HTTPSConnection(httplib.HTTPSConnection):
-    def __init__(self, host, port=None, key_file=None, cert_file=None, strict=None, timeout=socket._GLOBAL_DEFAULT_TIMEOUT, source_address=None, ssl_version=ssl.PROTOCOL_TLSv1, ciphers=None):
+    def __init__(self, host, port=None, key_file=None, cert_file=None, strict=None, timeout=socket._GLOBAL_DEFAULT_TIMEOUT, source_address=None, ssl_version=ssl.PROTOCOL_TLS, ciphers=None):
         import sys
         if sys.version_info >= (2,7,0):
             # source_address added for python issue 3972 Jan 2010. Note the 2.7 maint branch was Jul 2010. This is first seen in 2.7 alpha 2.
@@ -106,14 +106,14 @@ class TLS1HTTPSConnection(httplib.HTTPSConnection):
                 self.sock = sock
                 self._tunnel()
 
-        # Force use of TLSv1 with PROTOCOL_TLSv1
+        # Force use of TLSv1 with PROTOCOL_TLS
         # Default is PROTOCOL_SSLv23 which allows either 2 or 3
         # Another option is PROTOCOL_SSLv3
         # We want TLS1 to avoid POODLE vulnerability. In addition, some client/server combinations fail the handshake
         # if you start with SSL23 and the server wants TLS1. See geni-tools issue #745
         if self.ssl_version is None:
             #print "Requested a None ssl version"
-            self.ssl_version = ssl.PROTOCOL_TLSv1
+            self.ssl_version = ssl.PROTOCOL_TLS
         #print "Wrapping socket to use SSL version %s" % ssl._PROTOCOL_NAMES[self.ssl_version]
 
         if sys.version_info >= (2,7,0):
@@ -135,7 +135,7 @@ class TLS1P26HTTPS(httplib.HTTPS):
 
 class SafeTransportNoCert(xmlrpclib.SafeTransport):
     # A standard SafeTransport that honors the requested SSL timeout
-    def __init__(self, use_datetime=0, timeout=None, ssl_version=ssl.PROTOCOL_TLSv1, ciphers=None):
+    def __init__(self, use_datetime=0, timeout=None, ssl_version=ssl.PROTOCOL_TLS, ciphers=None):
         # Ticket #776: As of Python 2.7.9, server certs are verified by default.
         # But we don't have those. To preserve old functionality with new python,
         # pass an explicit context
@@ -184,7 +184,7 @@ class SafeTransportNoCert(xmlrpclib.SafeTransport):
 # or else "HIGH:MEDIUM:!ADH:!SSLv2:!MD5:!RC4:@STRENGTH", which is what we use (though python2.6 ignores it).
 # By specifying TLSv1 this works at servers that have disabled SSLv2 and SSLv3.
 def make_client(url, keyfile, certfile, verbose=False, timeout=None,
-                allow_none=False, ssl_version=ssl.PROTOCOL_TLSv1, ciphers="HIGH:MEDIUM:!ADH:!SSLv2:!MD5:!RC4:@STRENGTH"):
+                allow_none=False, ssl_version=ssl.PROTOCOL_TLS, ciphers="HIGH:MEDIUM:!ADH:!SSLv2:!MD5:!RC4:@STRENGTH"):
     """Create a connection to an XML RPC server, using SSL with client certificate
     authentication if requested.
     Returns the XML RPC server proxy.

--- a/src/gcf/omnilib/stitch/scs.py
+++ b/src/gcf/omnilib/stitch/scs.py
@@ -99,7 +99,7 @@ class Service(object):
 
         # As a sample of how to do make_client specifying the SSL version / ciphers (these are the defaults though):
 #        import ssl
-#        server = make_client(self.url, keyfile=self.key, certfile=self.cert, verbose=self.verbose, timeout=self.timeout, ssl_version=ssl.PROTOCOL_TLSv1, ciphers="HIGH:MEDIUM:!ADH:!SSLv2:!MD5:!RC4:@STRENGTH")
+#        server = make_client(self.url, keyfile=self.key, certfile=self.cert, verbose=self.verbose, timeout=self.timeout, ssl_version=ssl.PROTOCOL_TLS, ciphers="HIGH:MEDIUM:!ADH:!SSLv2:!MD5:!RC4:@STRENGTH")
 
         try:
             result = server.GetVersion()

--- a/src/gcf/omnilib/xmlrpc/client.py
+++ b/src/gcf/omnilib/xmlrpc/client.py
@@ -33,7 +33,7 @@ class SafeTransportWithCert(xmlrpclib.SafeTransport):
     a client X509 identity certificate.'''
 
     def __init__(self, use_datetime=0, keyfile=None, certfile=None,
-                 timeout=None, ssl_version=ssl.PROTOCOL_TLSv1, ciphers=None):
+                 timeout=None, ssl_version=ssl.PROTOCOL_TLS, ciphers=None):
         # Ticket #776: As of Python 2.7.9, server certs are verified by default.
         # But we don't have those. To preserve old functionality with new python,
         # pass an explicit context
@@ -84,7 +84,7 @@ class SafeTransportWithCert(xmlrpclib.SafeTransport):
 # A custom HTTPSConnection that calls ssl.wrap_socket specifying the desired ssl_version, defaulting to PROTOCOL_TLSv1 instead of PROTOTOCOL_SSLv23
 # Used directly by our SafeTransport, and indirectly by the below TLS1P26HTTPS
 class TLS1HTTPSConnection(httplib.HTTPSConnection):
-    def __init__(self, host, port=None, key_file=None, cert_file=None, strict=None, timeout=socket._GLOBAL_DEFAULT_TIMEOUT, source_address=None, ssl_version=ssl.PROTOCOL_TLSv1, ciphers=None):
+    def __init__(self, host, port=None, key_file=None, cert_file=None, strict=None, timeout=socket._GLOBAL_DEFAULT_TIMEOUT, source_address=None, ssl_version=ssl.PROTOCOL_TLS, ciphers=None):
         import sys
         if sys.version_info >= (2,7,0):
             # source_address added for python issue 3972 Jan 2010. Note the 2.7 maint branch was Jul 2010. This is first seen in 2.7 alpha 2.
@@ -136,7 +136,7 @@ class TLS1P26HTTPS(httplib.HTTPS):
 
 class SafeTransportNoCert(xmlrpclib.SafeTransport):
     # A standard SafeTransport that honors the requested SSL timeout
-    def __init__(self, use_datetime=0, timeout=None, ssl_version=ssl.PROTOCOL_TLSv1, ciphers=None):
+    def __init__(self, use_datetime=0, timeout=None, ssl_version=ssl.PROTOCOL_TLS, ciphers=None):
         # Ticket #776: As of Python 2.7.9, server certs are verified by default.
         # But we don't have those. To preserve old functionality with new python,
         # pass an explicit context
@@ -185,7 +185,7 @@ class SafeTransportNoCert(xmlrpclib.SafeTransport):
 # or else "HIGH:MEDIUM:!ADH:!SSLv2:!MD5:!RC4:@STRENGTH", which is what we use (though python2.6 ignores it).
 # By specifying TLSv1 this works at servers that have disabled SSLv2 and SSLv3.
 def make_client(url, keyfile, certfile, verbose=False, timeout=None,
-                allow_none=False, ssl_version=ssl.PROTOCOL_TLSv1, ciphers="HIGH:MEDIUM:!ADH:!SSLv2:!MD5:!RC4:@STRENGTH"):
+                allow_none=False, ssl_version=ssl.PROTOCOL_TLS, ciphers="HIGH:MEDIUM:!ADH:!SSLv2:!MD5:!RC4:@STRENGTH"):
     """Create a connection to an XML RPC server, using SSL with client certificate
     authentication if requested.
     Returns the XML RPC server proxy.


### PR DESCRIPTION
 * Due to the chnages in the underlying OpenSSL versions some minor changes to SSL protocol versions were implemented.
   These changes were needed to make omni run on newer Operating Systems using the updated OpenSSL version
